### PR TITLE
Set a minimum height for skill select area

### DIFF
--- a/src/Screens/Main/SearchMentor.tsx
+++ b/src/Screens/Main/SearchMentor.tsx
@@ -56,13 +56,11 @@ export default ({ navigation }: Props) => {
   };
 
   const [{ height }, onLayout] = useLayout();
-  let maxHeight = (height || 350) - 350;
 
-  // Make sure skill area has enough space even when keyboard is showing.
-  const minimumSkillAreaHeight = 250;
-  if (maxHeight < minimumSkillAreaHeight) {
-    maxHeight = minimumSkillAreaHeight;
-  }
+  // Make sure skill area has enough height even when keyboard is showing.
+  const min = 250;
+  const max = (height || 350) - 350;
+  const skillAreaHeight = max >= min ? max : min;
 
   return (
     <TitledContainer
@@ -114,7 +112,7 @@ export default ({ navigation }: Props) => {
               resizeMethod="scale"
             />
             <RN.ScrollView
-              style={{ ...styles.carouselContainer, height: maxHeight }}
+              style={{ ...styles.carouselContainer, height: skillAreaHeight }}
               showsHorizontalScrollIndicator={true}
               contentContainerStyle={styles.contentContainer}
             >

--- a/src/Screens/Main/SearchMentor.tsx
+++ b/src/Screens/Main/SearchMentor.tsx
@@ -56,7 +56,13 @@ export default ({ navigation }: Props) => {
   };
 
   const [{ height }, onLayout] = useLayout();
-  const maxHeight = (height || 350) - 350;
+  let maxHeight = (height || 350) - 350;
+
+  // Make sure skill area has enough space even when keyboard is showing.
+  const minimumSkillAreaHeight = 250;
+  if (maxHeight < minimumSkillAreaHeight) {
+    maxHeight = minimumSkillAreaHeight;
+  }
 
   return (
     <TitledContainer


### PR DESCRIPTION
The keyboard will hide the buttons because it makes more sense like this i think. the buttons are needed after the skills are selected.
like no need for buttons when typing

and when you wanna select skill, you tap it, first tap close the keyboard and second will select