### PR TITLE
display name, username == nimimerkki, käyttäjätunnus

### DIFF
--- a/e2e/changePasswordTest.spec.ts
+++ b/e2e/changePasswordTest.spec.ts
@@ -64,9 +64,9 @@ describe('changePassword', () => {
     await expect(element(by.id('main.settings.account.userName'))).toHaveText(
       mentee.loginName,
     );
-    await expect(element(by.id('main.settings.account.nickName'))).toHaveText(
-      mentee.displayName,
-    );
+    await expect(
+      element(by.id('main.settings.account.displayName')),
+    ).toHaveText(mentee.displayName);
     await expect(element(by.id('main.settings.account.email'))).toHaveText(
       mentee.email,
     );

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -70,7 +70,7 @@ export async function signIn(details: any) {
   );
   await scrollDownAndTap('onboarding.sign.in', 'onboarding.mentorlist.view');
 
-  await waitAndTypeText('onboarding.signUp.nickName', `${details.loginName}\n`);
+  await waitAndTypeText('onboarding.signUp.userName', `${details.loginName}\n`);
   await waitAndTypeText('onboarding.signUp.password', `${details.password}\n`);
 
   await waitFor(element(by.id('onboarding.signUp.button')))

--- a/e2e/signInTest.spec.ts
+++ b/e2e/signInTest.spec.ts
@@ -21,9 +21,9 @@ describe('SignIn', () => {
     await expect(element(by.id('main.settings.account.userName'))).toHaveText(
       mentee.loginName,
     );
-    await expect(element(by.id('main.settings.account.nickName'))).toHaveText(
-      mentee.displayName,
-    );
+    await expect(
+      element(by.id('main.settings.account.displayName')),
+    ).toHaveText(mentee.displayName);
     await expect(element(by.id('main.settings.account.email'))).toHaveText(
       mentee.email,
     );

--- a/e2e/signUpTest.spec.ts
+++ b/e2e/signUpTest.spec.ts
@@ -28,7 +28,7 @@ describe('SignUp', () => {
     await scrollDownAndTap('onboarding.sign.up', 'onboarding.mentorlist.view');
 
     await waitAndTypeText(
-      'onboarding.signUp.nickName',
+      'onboarding.signUp.userName',
       `${mentee.loginName}\n`,
     );
     await waitAndTypeText('onboarding.signUp.password', `${mentee.password}\n`);
@@ -67,9 +67,9 @@ describe('SignUp', () => {
     await expect(element(by.id('main.settings.account.userName'))).toHaveText(
       mentee.loginName,
     );
-    await expect(element(by.id('main.settings.account.nickName'))).toHaveText(
-      mentee.displayName,
-    );
+    await expect(
+      element(by.id('main.settings.account.displayName')),
+    ).toHaveText(mentee.displayName);
     await expect(element(by.id('main.settings.account.email'))).toHaveText(
       mentee.email,
     );

--- a/src/Screens/Main/Settings/UserAccount/MainForm.tsx
+++ b/src/Screens/Main/Settings/UserAccount/MainForm.tsx
@@ -53,11 +53,11 @@ export default ({ openPasswordForm, openEmailForm }: Props) => {
               <>
                 <Message
                   style={styles.fieldName}
-                  id="main.settings.account.nickName"
+                  id="main.settings.account.displayName"
                 />
                 <RN.Text
                   style={styles.fieldValueText}
-                  testID="main.settings.account.nickName"
+                  testID="main.settings.account.displayName"
                 >
                   {displayName}
                 </RN.Text>

--- a/src/Screens/components/LoginCard.tsx
+++ b/src/Screens/components/LoginCard.tsx
@@ -55,10 +55,10 @@ const LoginCard = ({
       <NamedInputField
         autoCapitalize="none"
         style={styles.nickNameInput}
-        name="onboarding.signUp.nickName"
+        name="onboarding.signUp.userName"
         onChangeText={onUserNameChange}
         autoCompleteType="off"
-        testID="onboarding.signUp.nickName"
+        testID="onboarding.signUp.userName"
       />
       <NamedInputField
         autoCapitalize="none"

--- a/src/localization/en.ts
+++ b/src/localization/en.ts
@@ -50,14 +50,14 @@ export const messages: { [key in MessageId]: string } = {
   'main.searchMentor.showButton': 'Show',
   'main.searchMentor.title': 'Search',
 
+  'main.settings.account.displayName': 'Display name',
+
   'main.settings.account.email.change': 'Change email',
   'main.settings.account.email.fail': 'Changing email failed!',
   'main.settings.account.email.fieldTitle': 'Email',
   'main.settings.account.email.missing': 'no email',
   'main.settings.account.email.success': 'Changing email succeeded!',
   'main.settings.account.email.title': 'Email',
-
-  'main.settings.account.nickName': 'Nickname',
 
   'main.settings.account.password.button': 'Change password',
   'main.settings.account.password.current': 'Current password',
@@ -151,10 +151,10 @@ export const messages: { [key in MessageId]: string } = {
 
   'onboarding.signUp.existingAccount.login': 'Login',
   'onboarding.signUp.existingAccount.title': 'I already have an account',
-  'onboarding.signUp.nickName': 'Nickname',
   'onboarding.signUp.password': 'Password',
   'onboarding.signUp.signUp': 'Sign up',
   'onboarding.signUp.title': 'Sign up',
+  'onboarding.signUp.userName': 'Username',
 
   'onboarding.welcome.button': 'Start',
   'onboarding.welcome.text1': 'Cool, that you have started using the service!',

--- a/src/localization/fi.ts
+++ b/src/localization/fi.ts
@@ -48,14 +48,14 @@ export const messages = {
   'main.searchMentor.showButton': 'Näytä',
   'main.searchMentor.title': 'Hae mentoria',
 
+  'main.settings.account.displayName': 'Nimimerkki',
+
   'main.settings.account.email.change': 'Muuta sähköposti',
   'main.settings.account.email.fail': 'Sähköpostin muutos epäonnistui!',
   'main.settings.account.email.fieldTitle': 'Sähköposti',
   'main.settings.account.email.missing': 'ei sähköpostia',
   'main.settings.account.email.success': 'Sähköpostin muutos onnistui!',
   'main.settings.account.email.title': 'Sähköposti',
-
-  'main.settings.account.nickName': 'Nimimerkki',
 
   'main.settings.account.password.button': 'Vaihda salasana',
   'main.settings.account.password.current': 'nykyinen salasana',
@@ -69,7 +69,7 @@ export const messages = {
   'main.settings.account.profile.title': 'Profiili',
 
   'main.settings.account.title': 'Asetukset',
-  'main.settings.account.userName': 'Käyttäjänimi',
+  'main.settings.account.userName': 'Käyttäjätunnus',
 
   'main.settings.deleteAccount.cancel': 'Peruuta',
   'main.settings.deleteAccount.deleteAccount': 'Poista tili',
@@ -143,16 +143,16 @@ export const messages = {
   'onboarding.signUp.error.passwordLong': 'Salasana on liian pitkä',
   'onboarding.signUp.error.passwordShort': 'Salasana on liian lyhyt',
   'onboarding.signUp.error.probablyNetwork': 'Yhteysvirhe',
-  'onboarding.signUp.error.userNameLong': 'Käyttäjänimi on liian Pitkä',
-  'onboarding.signUp.error.userNameShort': 'Käyttäjänimi on liian lyhyt',
-  'onboarding.signUp.error.userNameTaken': 'Käyttäjänimi on varattu',
+  'onboarding.signUp.error.userNameLong': 'Käyttäjätunnus on liian Pitkä',
+  'onboarding.signUp.error.userNameShort': 'Käyttäjätunnus on liian lyhyt',
+  'onboarding.signUp.error.userNameTaken': 'Käyttäjätunnus on varattu',
 
   'onboarding.signUp.existingAccount.login': 'Kirjaudu sisään',
   'onboarding.signUp.existingAccount.title': 'Minulla on jo tunnus',
-  'onboarding.signUp.nickName': 'Nimimerkki',
   'onboarding.signUp.password': 'Salasana',
   'onboarding.signUp.signUp': 'Luo tunnus',
   'onboarding.signUp.title': 'Luo tunnus',
+  'onboarding.signUp.userName': 'Käyttäjätunnus',
 
   'onboarding.welcome.button': 'Aloita',
   'onboarding.welcome.text1': 'Kiva, että otit palvelun käyttöön!',


### PR DESCRIPTION
in code and in labels there are multiple ways how display name and username are in finnish and in english. this pull request at least makes the labels inside app be consistent.

![Screenshot_20210226-092414](https://user-images.githubusercontent.com/59723/109275827-f08ba380-781d-11eb-9019-9caba5748c68.jpg)
![Screenshot_20210226-093329](https://user-images.githubusercontent.com/59723/109275833-f1243a00-781d-11eb-84dc-e9f88883039d.jpg)
![Screenshot_20210226-093354](https://user-images.githubusercontent.com/59723/109275837-f1bcd080-781d-11eb-9700-f2f5529c5d6c.jpg)
![Screenshot_20210226-093605](https://user-images.githubusercontent.com/59723/109275838-f2556700-781d-11eb-8ecf-259418013475.jpg)
![Screenshot_20210226-093619](https://user-images.githubusercontent.com/59723/109275841-f2556700-781d-11eb-907f-6d55cad69eb7.jpg)
![Screenshot_20210226-093647](https://user-images.githubusercontent.com/59723/109275842-f2edfd80-781d-11eb-90a0-1b1c8515b2be.jpg)
