### PR TITLE
Assume UTC for datetimes from API

### DIFF
--- a/src/lib/__tests__/validators.ts
+++ b/src/lib/__tests__/validators.ts
@@ -5,12 +5,21 @@ import * as validators from '../validators';
 import { describe, expect, it } from '@jest/globals';
 
 describe('unixTimeFromDateString', () => {
-  it('decodes js date iso string', () => {
-    const s = '2020-01-16T10:29:32.350430';
-    expect(validators.unixTimeFromDateString.decode(s)).toEqual(
-      right(new Date(s).getTime()),
-    );
-  });
+  const datimeTests = [
+    { datetime: '2020-01-16T10:29:32.350430', expected: 1579170572350 }, // for backwards compatibility, assume UTC
+    { datetime: '2020-01-16T10:29:32.350430Z', expected: 1579170572350 },
+    { datetime: '2020-01-16T10:29:32.350430+00:00', expected: 1579170572350 },
+    { datetime: '2020-01-16T10:29:32.350430-00:00', expected: 1579170572350 },
+    { datetime: '2020-01-16T12:29:32.350430+02:00', expected: 1579170572350 }, // same as above but in different timezone
+  ];
+  for (const t of datimeTests) {
+    it(`decodes js date iso string ${t.datetime}`, () => {
+      expect(validators.unixTimeFromDateString.decode(t.datetime)).toEqual(
+        right(t.expected),
+      );
+    });
+  }
+
   it('fails to decode random string', () => {
     expect(validators.unixTimeFromDateString.decode('foo')).toEqual(
       left(expect.any(Array)),

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -7,7 +7,24 @@ export const unixTimeFromDateString = new t.Type<number, string, unknown>(
   (u): u is number => typeof u === 'number',
   (u, c) =>
     either.chain(t.string.validate(u, c), s => {
-      const n = new Date(s).getTime();
+      let datetimeString = s;
+
+      // datetime strings from API dont include timezone information
+      // patch it so that it would at least have the Z at the end.
+      // If this situation changes some day. this code should detect
+      // if timezone info is already there.
+      // At the time of writing. Android only supports Z and +/-hh:mm formats,
+      // so only check those.
+
+      const len = datetimeString.length;
+      const endsWithZone =
+        datetimeString.slice(-1).toUpperCase() === 'Z' || // ends with Z
+        ['+', '-'].includes(datetimeString.slice(len - 6, len - 5)); // +/-hh:mm
+
+      if (!endsWithZone) {
+        datetimeString = `${datetimeString}Z`;
+      }
+      const n = new Date(datetimeString).getTime();
       return isNaN(n) ? t.failure(u, c) : t.success(n);
     }),
   a => new Date(a).toISOString(),


### PR DESCRIPTION
Datetimes from API dont have any timezone information on them.

![timestampgeneration](https://user-images.githubusercontent.com/59723/120097705-c0b0ac80-c13a-11eb-9995-3a9d188d237f.png)
![pythonutcdifference](https://user-images.githubusercontent.com/59723/120097739-e5a51f80-c13a-11eb-9e70-94defe95e5a0.png)


Making JS Dates from them on Android and iOS behave differently.
new Date("2020-01-16T10:29:32.350430")
Android sees this as UTC time but iOS sees this as local time.

This PR adds Z to the datetimes so that they are detected as UTC datetimes on both platforms.
But try to support possible fix in the future by detecting if datetimes already have timezone information on them.