### PR TITLE
Use mavenCentral too to download deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     }
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -43,6 +44,7 @@ allprojects {
             // All of Detox' artifacts are provided via the npm module
             url "$rootDir/../node_modules/detox/Detox-android"
         }
+        mavenCentral()
         jcenter()
         maven { url 'https://www.jitpack.io' }
     }


### PR DESCRIPTION
Problem:
Android builds in appcenter started failing.

```
* What went wrong:
Execution failed for task ':app:lintVitalRelease'.
> Could not resolve all files for configuration ':app:lintClassPath'.
   > Could not download groovy-all-2.4.15.jar (org.codehaus.groovy:groovy-all:2.4.15)
      > Could not get resource 'https://jcenter.bintray.com/org/codehaus/groovy/groovy-all/2.4.15/groovy-all-2.4.15.jar'.
         > Could not GET 'https://jcenter.bintray.com/org/codehaus/groovy/groovy-all/2.4.15/groovy-all-2.4.15.jar'.
            > Connection reset
   > Could not download kotlin-reflect-1.3.50.jar (org.jetbrains.kotlin:kotlin-reflect:1.3.50)
      > Could not get resource 'https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-reflect/1.3.50/kotlin-reflect-1.3.50.jar'.
         > Could not GET 'https://jcenter.bintray.com/org/jetbrains/kotlin/kotlin-reflect/1.3.50/kotlin-reflect-1.3.50.jar'.
            > Connection reset
```

I contacted appcenter support  and they say this is because of the shutdown of jcentral. They didn't give the actual reason.

Solution:
React native 0.65.rc-0 has replaced jcentral with mavenCentral. But we cannot do this yet because all of the required dependencies are not yet in mavenCentral. But including both works at the moment.

https://react-native-community.github.io/upgrade-helper/?from=0.63.4&to=0.65.0-rc.0