### PR TITLE
Setup github actions for unittests and linters

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,8 @@ jobs:
         node-version: '14'
     - name: Install dependencies
       run: npm install
+    - name: Copy config template
+      run: cp config.template.android.json config.json
     - name: Lint code
       run: npm run lint
   unittest:
@@ -27,5 +29,7 @@ jobs:
         node-version: '14'
     - name: Install dependencies
       run: npm install
+    - name: Copy config template
+      run: cp config.template.android.json config.json
     - name: Run tests
       run: npm run unittest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
       run: npm run lint
   unittest:
     name: Unittest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [push]
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install dependencies
+      run: npm install
+    - name: Lint code
+      run: npm run lint
+  unittest:
+    name: Unittest
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm run unittest

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "npm run lint && jest",
+    "unittest": "jest",
     "eslint:check": "eslint --print-config ./src/index.ts | eslint-config-prettier-check",
     "eslint:fix": "npm run eslint:check && eslint --fix '{src,e2e}/**/*.{ts,tsx}'",
     "eslint": "npm run eslint:check && eslint '{src,e2e}/**/*.{ts,tsx}'",


### PR DESCRIPTION
What was changed?

I setup github actions to run linters and unittest on push. I did not bother setting up e2e. Not gonna do that on this PR. If someone wants to do it, it is highly encouraged.

Why was the change made?

It makes sense to check that linters and tests have been ran before merging : ).