### PR TITLE
Lint: Require empty line before certain statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,19 @@ module.exports = {
     // eslint cannot differentiate between types and values
     // they live in diffrent namespaces.
     'no-shadow': ['off'],
-    '@typescript-eslint/no-shadow': ['error']
+    '@typescript-eslint/no-shadow': ['error'],
+    'padding-line-between-statements': [
+      'error',
+      { 'blankLine': 'always', 'prev': '*', 'next': 'function' },
+      { 'blankLine': 'always', 'prev': 'function', 'next': '*' },
+      { 'blankLine': 'always', 'prev': '*', 'next': 'return' },
+      { 'blankLine': 'always', 'prev': '*', 'next': 'if' },
+      { 'blankLine': 'always', 'prev': 'if', 'next': '*' },
+      {
+        'blankLine': 'always',
+        'prev': '*',
+        'next': ['multiline-const', 'multiline-let']
+      }
+    ],
   },
 };

--- a/e2e/browseMentorsTest.spec.ts
+++ b/e2e/browseMentorsTest.spec.ts
@@ -73,6 +73,7 @@ describe('Browse mentors', () => {
         continue;
       }
     }
+
     const expectedMentors = {
       [accountFixtures.mentors[0].displayName]: true,
       [accountFixtures.mentors[1].displayName]: true,

--- a/e2e/filterSkillTest.spec.ts
+++ b/e2e/filterSkillTest.spec.ts
@@ -75,6 +75,7 @@ describe('Skill filter', () => {
         continue;
       }
     }
+
     const expectedMentors = {
       [accountFixtures.mentors[0].displayName]: true,
       [accountFixtures.mentors[1].displayName]: true,

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -109,6 +109,7 @@ export async function APIAccessToken(login_name: string, password: string) {
     body: JSON.stringify({ login_name: login_name, password: password }),
   });
   const tokens: any = await loginResponse.json();
+
   return tokens.tokens.access_token;
 }
 
@@ -119,11 +120,13 @@ export async function APIUsers(access_token: string) {
   const headers = {
     Authorization: `Bearer ${access_token}`,
   };
+
   const usersResponse = await fetch(`${API_URL}/users`, {
     method: 'GET',
     headers: headers,
   });
   const users: any = await usersResponse.json();
+
   return users.resources;
 }
 
@@ -141,6 +144,7 @@ export async function APIDeleteAccounts() {
     if (user.role === 'admin') {
       continue;
     }
+
     await fetch(`${API_URL}/accounts/${user.account_id}`, {
       method: 'DELETE',
       headers: headers,
@@ -164,6 +168,7 @@ export async function APISignUpMentee(mentee: any) {
     }),
   });
   const access_token = await APIAccessToken(mentee.loginName, mentee.password);
+
   const headers = {
     Authorization: `Bearer ${access_token}`,
   };
@@ -191,6 +196,7 @@ export async function APISignUpMentee(mentee: any) {
  */
 export async function APISignUpMentor(mentor: any) {
   const admin_access_token = await APIAdminAccessToken();
+
   const admin_headers = {
     Authorization: `Bearer ${admin_access_token}`,
   };
@@ -208,6 +214,7 @@ export async function APISignUpMentor(mentor: any) {
     }),
   });
   const access_token = await APIAccessToken(mentor.loginName, mentor.password);
+
   const headers = {
     Authorization: `Bearer ${access_token}`,
   };
@@ -257,11 +264,13 @@ export async function APIBan(sender: any, reciever: any) {
   let sender_info = info.find(
     (o: any) => o.display_name === sender.displayName,
   );
+
   let reciever_info = info.find(
     (o: any) => o.display_name === reciever.displayName,
   );
 
   const access_token = await APIAccessToken(sender.loginName, sender.password);
+
   const headers = {
     Authorization: `Bearer ${access_token}`,
   };

--- a/src/Screens/Main/BuddyList/BannedList.tsx
+++ b/src/Screens/Main/BuddyList/BannedList.tsx
@@ -25,6 +25,7 @@ type Props = navigationProps.NavigationProps<BannedListRoute, ChatRoute>;
 
 export default ({ navigation }: Props) => {
   const remoteBuddies = useSelector(buddyState.getBannedBuddies);
+
   const onPress = (buddyId: string) => {
     navigation.navigate('Main/Chat', { buddyId });
   };

--- a/src/Screens/Main/BuddyList/Button.tsx
+++ b/src/Screens/Main/BuddyList/Button.tsx
@@ -18,6 +18,7 @@ const Button = ({ style, buddyId, name, onPress, ...viewProps }: Props) => {
   const onPressBuddy = () => onPress(buddyId);
   const hasNewMessages = useSelector(hasUnseen(buddyId));
   const color = getBuddyColor(buddyId);
+
   return (
     <Card style={[styles.button, style]} {...viewProps}>
       <RN.TouchableOpacity style={styles.content} onPress={onPressBuddy}>

--- a/src/Screens/Main/BuddyList/index.tsx
+++ b/src/Screens/Main/BuddyList/index.tsx
@@ -42,6 +42,7 @@ export default ({ navigation }: Props) => {
   const items: DropDownItem[] = [
     { textId: 'main.chat.navigation.banned', onPress: navigateToBanned },
   ];
+
   return (
     <TitledContainer
       TitleComponent={

--- a/src/Screens/Main/Chat/Input.tsx
+++ b/src/Screens/Main/Chat/Input.tsx
@@ -20,6 +20,7 @@ type Props = {
 
 export default ({ buddyId }: Props) => {
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const sendMessage = (payload: messageApi.SendMessageParams) => {
     dispatch({ type: 'newMessage/send/start', payload });
   };
@@ -36,6 +37,7 @@ export default ({ buddyId }: Props) => {
   const onSend = () => {
     sendMessage({ buddyId, text: messageContent });
   };
+
   return (
     <SafeAreaView style={styles.container} forceInset={{ bottom: 'always' }}>
       <RN.View style={styles.inputContainer}>

--- a/src/Screens/Main/Chat/MessageList/Message.tsx
+++ b/src/Screens/Main/Chat/MessageList/Message.tsx
@@ -35,6 +35,7 @@ const Message = ({ value: message }: MessageProps) => {
   const hours = addZero(date.getHours());
   const minutes = addZero(date.getMinutes());
   const timeText = `${hours}:${minutes}`;
+
   return (
     <RN.View style={[bubbleStyle, styles.bubble]}>
       <RN.View>

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -43,6 +43,7 @@ export function toRenderable(messages: messageApi.Message[]): Renderable[] {
   return messages
     .reduce((acc: Renderable[], m) => {
       const last = acc[acc.length - 1];
+
       const next = {
         type: 'Message' as const,
         value: m,
@@ -50,16 +51,20 @@ export function toRenderable(messages: messageApi.Message[]): Renderable[] {
       };
       const date = getDate(next.value.sentTime);
       const nextDate = { type: 'Date' as const, value: date, id: date };
+
       if (
         !!last &&
         last.type === 'Message' &&
         getDate(last.value.sentTime) === date
       ) {
         acc.push(next);
+
         return acc;
       }
+
       acc.push(nextDate);
       acc.push(next);
+
       return acc;
     }, [])
     .reverse();
@@ -77,6 +82,7 @@ export default ({ buddyId }: Props) => {
   const messageList = useSelector(getMessagesByBuddyId(buddyId));
   messageList.sort(({ sentTime: A }, { sentTime: B }) => A - B);
   const messages = toRenderable(messageList);
+
   return (
     <RN.FlatList
       contentContainerStyle={styles.scrollContent}

--- a/src/Screens/Main/Chat/Title.tsx
+++ b/src/Screens/Main/Chat/Title.tsx
@@ -31,13 +31,16 @@ const Title: React.FC<Props> = ({ style, onPress, name, buddyId }) => {
   const color = getBuddyColor(buddyId);
   const isBanned = ReactRedux.useSelector(selectors.getIsBanned(buddyId));
   const dispatch = ReactRedux.useDispatch<redux.Dispatch<actions.Action>>();
+
   const banBuddy = () => {
     dispatch({ type: 'buddies/ban/start', payload: { buddyId } });
   };
+
   const handleBan = () => {
     banBuddy();
     onPress();
   };
+
   const dropdownItems: DropDownItem[] = [
     { textId: 'main.chat.ban', onPress: () => setDialogOpen(true) },
   ];

--- a/src/Screens/Main/Chat/index.tsx
+++ b/src/Screens/Main/Chat/index.tsx
@@ -14,13 +14,16 @@ export type ChatRoute = {
 };
 
 type Props = navigationProps.NavigationProps<ChatRoute, ChatRoute>;
+
 const Chat = ({ navigation }: Props) => {
   const goBack = () => {
     navigation.goBack();
   };
   const buddyId = navigation.getParam('buddyId');
+
   const keyboardViewBehaviour =
     RN.Platform.OS === 'ios' ? 'padding' : undefined;
+
   return (
     <RN.View style={styles.screen}>
       <Title style={styles.title} onPress={goBack} buddyId={buddyId} />

--- a/src/Screens/Main/MentorCardExpanded.tsx
+++ b/src/Screens/Main/MentorCardExpanded.tsx
@@ -39,12 +39,15 @@ type Props = OwnProps;
 const MentorCardExpanded = ({ navigation }: Props) => {
   const mentor = navigation.getParam('mentor');
   const color = getBuddyColor(mentor.buddyId);
+
   const goBack = () => {
     navigation.goBack();
   };
+
   const navigateToChat = () => {
     navigation.navigate('Main/Chat', { buddyId: mentor.buddyId });
   };
+
   return (
     <RN.View style={styles.container}>
       <MentorTitle

--- a/src/Screens/Main/SearchMentor.tsx
+++ b/src/Screens/Main/SearchMentor.tsx
@@ -38,6 +38,7 @@ export default ({ navigation }: Props) => {
 
   const allSkills = useSelector(mentorState.getSkillList);
   const selectedSkills = useSelector(mentorState.getSelectedSkills);
+
   const skillsToShow = allSkills.filter(skill =>
     skill.toLowerCase().includes(skillSearch.toLowerCase()),
   );

--- a/src/Screens/Main/Settings/BottomCard.tsx
+++ b/src/Screens/Main/Settings/BottomCard.tsx
@@ -20,6 +20,7 @@ type Props = {
 
 export default ({ navigateToDeleteAccount, navigateToLogout }: Props) => {
   const isMentor = useSelector(tokenState.isMentor);
+
   return (
     <Card style={styles.card}>
       <Message

--- a/src/Screens/Main/Settings/DeleteAccount.tsx
+++ b/src/Screens/Main/Settings/DeleteAccount.tsx
@@ -29,13 +29,16 @@ type Props = navigationProps.NavigationProps<
 
 export default ({ navigation }: Props) => {
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const onDeleteAccount = () => {
     dispatch(actions.make('deleteAccount/start')(undefined));
     navigateOnboarding(navigation);
   };
+
   const onGoBack = () => {
     navigation.goBack();
   };
+
   return (
     <RN.View style={styles.screen}>
       <ScreenTitle

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -39,6 +39,7 @@ export default ({ navigation }: Props) => {
   const onGoBack = () => {
     navigation.goBack();
   };
+
   const onButtonPress = () => {
     dispatch(changeEmailState.changeEmail({ email, account: account }));
   };
@@ -48,6 +49,7 @@ export default ({ navigation }: Props) => {
     if (RD.isSuccess(requestState)) {
       setEmail(requestState.value.email ?? '');
       const timeout = setTimeout(onGoBack, changeEmailState.coolDownDuration);
+
       return () => clearTimeout(timeout);
     }
   }, [requestState]);

--- a/src/Screens/Main/Settings/Logout.tsx
+++ b/src/Screens/Main/Settings/Logout.tsx
@@ -26,13 +26,16 @@ type Props = navigationProps.NavigationProps<LogoutRoute, MentorListRoute>;
 
 export default ({ navigation }: Props) => {
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const onLogout = () => {
     dispatch(actions.make('logout/logout')(undefined));
     navigateOnboarding(navigation);
   };
+
   const onGoBack = () => {
     navigation.goBack();
   };
+
   return (
     <RN.View style={styles.screen}>
       <ScreenTitle id="main.settings.logout.title" onBack={onGoBack} />

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -49,6 +49,7 @@ export default ({ navigation }: Props) => {
   const onGoBack = () => {
     navigation.goBack();
   };
+
   const onButtonPress = () => {
     dispatch(state.changePassword({ currentPassword, newPassword }));
   };
@@ -60,6 +61,7 @@ export default ({ navigation }: Props) => {
       setNewPassword('');
       setRepeatedNewPassword('');
       const timeout = setTimeout(onGoBack, state.coolDownDuration);
+
       return () => clearTimeout(timeout);
     }
   }, [requestState]);

--- a/src/Screens/Main/Settings/UserAccount/AlertBox.tsx
+++ b/src/Screens/Main/Settings/UserAccount/AlertBox.tsx
@@ -17,6 +17,7 @@ type Props = {
 
 export default (props: Props) => {
   const opacity = React.useRef(new RN.Animated.Value(0)).current;
+
   const fade = () =>
     RN.Animated.sequence([
       RN.Animated.timing(opacity, {
@@ -39,6 +40,7 @@ export default (props: Props) => {
       }),
     ]).start();
   React.useEffect(fade, []);
+
   return (
     <RN.Animated.View style={[styles.container, props.style, { opacity }]}>
       <RN.Image

--- a/src/Screens/Main/Settings/UserAccount/MainForm.tsx
+++ b/src/Screens/Main/Settings/UserAccount/MainForm.tsx
@@ -26,6 +26,7 @@ export default ({ openPasswordForm, openEmailForm }: Props) => {
   };
   const userAccount = useSelector(userAccountState.getAccount);
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const fetchUserAccount = () => {
     dispatch({ type: 'userAccount/get/start', payload: undefined });
   };
@@ -33,6 +34,7 @@ export default ({ openPasswordForm, openEmailForm }: Props) => {
   const data = RD.remoteData.map(userAccount, account =>
     tuple(account, account.userName !== account.displayName),
   );
+
   return (
     <>
       <Message style={styles.accountSettingsText} id="main.settings.title" />

--- a/src/Screens/Main/Settings/index.tsx
+++ b/src/Screens/Main/Settings/index.tsx
@@ -30,15 +30,19 @@ const Settings = ({ navigation }: Props) => {
   const onNavigateToLogout = () => {
     navigation.navigate('Main/Settings/Logout', {});
   };
+
   const onNavigateToDeleteAccount = () => {
     navigation.navigate('Main/Settings/DeleteAccount', {});
   };
+
   const onNavigateToPasswordChange = () => {
     navigation.navigate('Main/Settings/PasswordChange', {});
   };
+
   const onNavigateToEmailChange = () => {
     navigation.navigate('Main/Settings/EmailChange', {});
   };
+
   return (
     <TitledContainer
       TitleComponent={

--- a/src/Screens/Main/Tabs.tsx
+++ b/src/Screens/Main/Tabs.tsx
@@ -102,6 +102,7 @@ const TabBar = ({
 
 const UnseenDot = () => {
   const isUnseen = reactRedux.useSelector(isAnyMessageUnseen);
+
   return isUnseen ? <RN.View style={unseenDotStyles.dot} /> : null;
 };
 

--- a/src/Screens/Onboarding/DisplayName.tsx
+++ b/src/Screens/Onboarding/DisplayName.tsx
@@ -24,14 +24,17 @@ type Props = navigationProps.NavigationProps<DisplayNameRoute, EmailRoute>;
 const DisplayName = ({ navigation }: Props) => {
   const { userName, password } = navigation.getParam('credentials');
   const [displayName, setDisplayName] = React.useState(userName);
+
   const goBack = () => {
     navigation.goBack();
   };
+
   const navigateToEmailScreen = () => {
     navigation.navigate('Onboarding/Email', {
       user: { userName, password, displayName },
     });
   };
+
   return (
     <OnboardingBackground testID="onboarding.displayName.view">
       <Card style={styles.card}>

--- a/src/Screens/Onboarding/Email.tsx
+++ b/src/Screens/Onboarding/Email.tsx
@@ -28,6 +28,7 @@ const Email = ({ navigation }: Props) => {
   const goBack = () => {
     navigation.goBack();
   };
+
   const navigateNext = () => {
     navigation.navigate('Onboarding/PrivacyPolicy', {
       user: {
@@ -36,6 +37,7 @@ const Email = ({ navigation }: Props) => {
       },
     });
   };
+
   return (
     <OnboardingBackground testID="onboarding.email.view">
       <Card style={styles.card}>

--- a/src/Screens/Onboarding/MentorList.tsx
+++ b/src/Screens/Onboarding/MentorList.tsx
@@ -25,6 +25,7 @@ const MentorList = (props: Props) => {
   const navigateNext = () => {
     props.navigation.navigate('Onboarding/Sign', {});
   };
+
   return (
     <Background>
       <SafeAreaView

--- a/src/Screens/Onboarding/PrivacyPolicy.tsx
+++ b/src/Screens/Onboarding/PrivacyPolicy.tsx
@@ -52,13 +52,16 @@ const PrivacyPolicy = ({
     }
   }, [accessToken]);
   const [isAgreed, setAgreed] = React.useState(false);
+
   const goBack = () => {
     navigation.goBack();
   };
+
   const onNextPress = () => {
     const user = navigation.getParam('user');
     createUser(user);
   };
+
   return (
     <OnboardingBackground testID="onboarding.privacyPolicy.view">
       <Card style={styles.card}>

--- a/src/Screens/Onboarding/Sign.tsx
+++ b/src/Screens/Onboarding/Sign.tsx
@@ -25,12 +25,15 @@ export default ({ navigation }: Props) => {
   const navigateSignUp = () => {
     navigation.navigate('Onboarding/SignUp', {});
   };
+
   const navigateSignIn = () => {
     navigation.navigate('Onboarding/SignIn', {});
   };
+
   const goBack = () => {
     navigation.goBack();
   };
+
   return (
     <OnboardingBackground testID="onboarding.sign.view">
       <Card style={styles.card}>

--- a/src/Screens/Onboarding/SignIn.tsx
+++ b/src/Screens/Onboarding/SignIn.tsx
@@ -36,12 +36,15 @@ const SignIn = (props: Props) => {
       navigateMain(props.navigation);
     }
   }, [props.accessToken]);
+
   const goBack = () => {
     props.navigation.goBack();
   };
+
   const onLogin = (credentials: authApi.Credentials) => {
     props.login(credentials);
   };
+
   // React.useEffect(() => {
   //   props.login({ userName: 'test', password: 'test' });
   // }, []);

--- a/src/Screens/Onboarding/SignUp.tsx
+++ b/src/Screens/Onboarding/SignUp.tsx
@@ -20,6 +20,7 @@ export type SignUpRoute = {
 };
 
 type Props = navigationProps.NavigationProps<SignUpRoute, DisplayNameRoute>;
+
 const SignUp = ({ navigation }: Props) => {
   const [credentialsCheck, checkCredentials, resetCredentialsCheck] =
     useRemoteData(accountApi.checkCredentials);
@@ -36,9 +37,11 @@ const SignUp = ({ navigation }: Props) => {
   const goBack = () => {
     navigation.goBack();
   };
+
   const onSignUp = (credentials: authApi.Credentials) => {
     checkCredentials(credentials);
   };
+
   const getErrorMessageId: () => localization.MessageId = () =>
     pipe(
       credentialsCheck,
@@ -49,6 +52,7 @@ const SignUp = ({ navigation }: Props) => {
         () => localization.blank,
       ),
     );
+
   return (
     <OnboardingBackground testID={'onboarding.signUp.view'}>
       <LoginCard

--- a/src/Screens/Onboarding/navigateMain.ts
+++ b/src/Screens/Onboarding/navigateMain.ts
@@ -17,6 +17,7 @@ const navigateMain = <
   if (isLocked) {
     return;
   }
+
   const resetAction = reactNavigation.StackActions.reset({
     index: 0,
     actions: [

--- a/src/Screens/components/Button.tsx
+++ b/src/Screens/components/Button.tsx
@@ -54,6 +54,7 @@ const Button = ({
 };
 
 const borderRadius = 18;
+
 const styles = RN.StyleSheet.create({
   container: {
     minHeight: 40,

--- a/src/Screens/components/ButtonContainer.tsx
+++ b/src/Screens/components/ButtonContainer.tsx
@@ -26,6 +26,7 @@ const ButtonContainer: React.FC<Props> = ({
 };
 
 const borderRadius = 18;
+
 const styles = RN.StyleSheet.create({
   container: {
     minHeight: 40,

--- a/src/Screens/components/DropDownMenu.tsx
+++ b/src/Screens/components/DropDownMenu.tsx
@@ -21,6 +21,7 @@ interface Props {
 
 const DropDown: React.FC<Props> = ({ items, testID, tintColor }) => {
   const [isOpen, setOpen] = React.useState(false);
+
   const toggleOpen = () => {
     setOpen(!isOpen);
   };

--- a/src/Screens/components/ErrorMessage.tsx
+++ b/src/Screens/components/ErrorMessage.tsx
@@ -18,6 +18,7 @@ interface Props<E> {
 
 function ErrorMessage<E>({ style, data, getMessageId, testID }: Props<E>) {
   const opacity = React.useRef(new RN.Animated.Value(0)).current;
+
   const defaultConfig = {
     animation: {
       useNativeDriver: true,
@@ -27,6 +28,7 @@ function ErrorMessage<E>({ style, data, getMessageId, testID }: Props<E>) {
     },
     messageId: localization.blank,
   };
+
   const { animation, messageId } = pipe(
     data,
     RD.fold(
@@ -47,6 +49,7 @@ function ErrorMessage<E>({ style, data, getMessageId, testID }: Props<E>) {
   React.useEffect(() => {
     RN.Animated.timing(opacity, animation).start();
   }, [RD.isFailure(data)]);
+
   return (
     <AnimatedMessage
       style={[styles.message, { opacity }, style]}

--- a/src/Screens/components/ImmediatelyNavigateBack.tsx
+++ b/src/Screens/components/ImmediatelyNavigateBack.tsx
@@ -6,6 +6,7 @@ type Props = {
 
 const ImmediatelyNavigateBack = ({ goBack }: Props) => {
   React.useEffect(goBack, []);
+
   return null;
 };
 

--- a/src/Screens/components/Link.tsx
+++ b/src/Screens/components/Link.tsx
@@ -17,6 +17,7 @@ const Link = ({ style, linkName, url }: Props) => {
   const onPress = () => {
     RN.Linking.openURL(url);
   };
+
   return (
     <RN.TouchableOpacity style={[styles.touchable, style]} onPress={onPress}>
       <Message style={styles.linkText} id={linkName} />

--- a/src/Screens/components/LoginCard.tsx
+++ b/src/Screens/components/LoginCard.tsx
@@ -38,17 +38,22 @@ const LoginCard = ({
     userName: '',
     password: '',
   });
+
   const onChangeCredentials = (newCredentials: authApi.Credentials) => {
     if (onChange) {
       onChange(credentials);
     }
+
     setCredentials(newCredentials);
   };
+
   const onUserNameChange = (userName: string) =>
     onChangeCredentials({ ...credentials, userName });
+
   const onPasswordChange = (password: string) =>
     onChangeCredentials({ ...credentials, password });
   const isEmptyFields = !credentials.password || !credentials.userName;
+
   return (
     <Card {...viewProps}>
       <Message style={styles.title} id={titleMessageId} />

--- a/src/Screens/components/MentorCard.tsx
+++ b/src/Screens/components/MentorCard.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 const MentorCard: React.FC<Props> = ({ onPress, style, mentor }) => {
   const color = getBuddyColor(mentor.buddyId);
+
   return (
     <Card style={[styles.card, style]}>
       <MentorTitle mentor={mentor} />

--- a/src/Screens/components/MentorList.tsx
+++ b/src/Screens/components/MentorList.tsx
@@ -26,6 +26,7 @@ export default ({ onPress, testID }: Props) => {
   const selectedSkills = useSelector(mentorState.getSelectedSkills);
 
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const fetchMentors = () => {
     dispatch({ type: 'mentors/start', payload: undefined });
   };

--- a/src/Screens/components/MentorStory.tsx
+++ b/src/Screens/components/MentorStory.tsx
@@ -12,6 +12,7 @@ type Props = {
 
 const MentorStory = ({ style, story, showAll }: Props) => {
   const numberOfLines = showAll ? undefined : 5;
+
   return (
     <RN.View style={[styles.container, style]}>
       <RN.Text style={styles.story} numberOfLines={numberOfLines}>

--- a/src/Screens/components/MentorTitle.tsx
+++ b/src/Screens/components/MentorTitle.tsx
@@ -31,6 +31,7 @@ const MentorTitle: React.FC<Props> = ({
 }) => {
   const Wrapper = safeArea ? SafeAreaWrapper : React.Fragment;
   const color = getBuddyColor(buddyId);
+
   return (
     <RN.View style={[styles.blob, { backgroundColor: color }, style]}>
       <Wrapper>

--- a/src/Screens/components/MessageButton.tsx
+++ b/src/Screens/components/MessageButton.tsx
@@ -29,6 +29,7 @@ export default ({ onPress, style, messageId, messageStyle, testID }: Props) => {
 };
 
 const borderRadius = 18;
+
 const styles = RN.StyleSheet.create({
   container: {
     minHeight: 40,

--- a/src/Screens/components/MessageButtonWithIcon.tsx
+++ b/src/Screens/components/MessageButtonWithIcon.tsx
@@ -37,6 +37,7 @@ const FilterButton: React.FC<Props> = ({
 export default FilterButton;
 
 const borderRadius = 18;
+
 const styles = RN.StyleSheet.create({
   icon: {
     tintColor: colors.blueGray,

--- a/src/Screens/components/RemoteData.tsx
+++ b/src/Screens/components/RemoteData.tsx
@@ -27,6 +27,7 @@ function RemoteData<E, A>({
       fetchData();
     }
   });
+
   return pipe(
     data,
     RD.fold(

--- a/src/Screens/components/Spinner.tsx
+++ b/src/Screens/components/Spinner.tsx
@@ -5,6 +5,7 @@ import colors from './colors';
 
 export default ({ style, ...props }: Omit<RN.ImageProps, 'source'>) => {
   const spinState = React.useRef(new RN.Animated.Value(0)).current;
+
   const spin = () =>
     RN.Animated.loop(
       RN.Animated.timing(spinState, {
@@ -15,6 +16,7 @@ export default ({ style, ...props }: Omit<RN.ImageProps, 'source'>) => {
       }),
     ).start();
   React.useEffect(spin, []);
+
   return (
     <RN.Animated.Image
       {...props}

--- a/src/Screens/components/TitledContainer.tsx
+++ b/src/Screens/components/TitledContainer.tsx
@@ -27,6 +27,7 @@ const TitledContainer: React.FC<Props> = ({
     </RN.View>
   );
 };
+
 const styles = RN.StyleSheet.create({
   background: {
     flex: 1,

--- a/src/Screens/components/getBuddyColor.ts
+++ b/src/Screens/components/getBuddyColor.ts
@@ -10,5 +10,6 @@ export default (str: string) => {
   const num = Math.floor(
     str.charCodeAt(0) * str.charCodeAt(1) + str.charCodeAt(2) / 11,
   );
+
   return mapping[num % 3];
 };

--- a/src/Screens/components/shadow.ts
+++ b/src/Screens/components/shadow.ts
@@ -11,6 +11,7 @@ function interpolate(
   const outputRangeLen = outputRange[1] - outputRange[0];
   const multiplier = outputRangeLen / inputRangeLen;
   const value = input - inputRange[0];
+
   return value * multiplier;
 }
 
@@ -18,10 +19,12 @@ function shadow(value?: number): RN.ViewStyle {
   const shadowRadius = value || 7;
   const shadowRadiusRange: [number, number] = [1, 16];
   const elevation = interpolate(shadowRadius, shadowRadiusRange, [1, 24]);
+
   const shadowOffset = {
     width: 0,
     height: interpolate(shadowRadius, shadowRadiusRange, [1, 12]),
   };
+
   const shadowOpacity = interpolate(
     shadowRadius,
     shadowRadiusRange,

--- a/src/Screens/index.tsx
+++ b/src/Screens/index.tsx
@@ -66,6 +66,7 @@ type Screen =
   | typeof SearchMentor;
 
 export type Route = keyof typeof routes;
+
 const routes: {
   [name in RouteName]: { screen: Screen };
 } = {
@@ -126,10 +127,12 @@ const routes: {
 };
 
 const initialRouteName: RouteName = 'Splash';
+
 const config = {
   initialRouteName,
   headerMode: 'none' as const,
 };
+
 const StackNavigator = reactNavigationStack.createStackNavigator(
   routes,
   config,

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -11,6 +11,7 @@ import * as config from './config';
 import * as authApi from './auth';
 
 type ApiUser = t.TypeOf<typeof userType>;
+
 const userType = t.strict({
   display_name: t.string,
   role: t.union([t.literal('mentee'), t.literal('mentor'), t.literal('admin')]),
@@ -133,6 +134,7 @@ export function createUser(
   user: User,
 ): TE.TaskEither<string, authApi.AccessToken> {
   const { userName, password } = user;
+
   return pipe(
     user,
     postAccount,
@@ -170,10 +172,15 @@ export function checkCredentials({
       userName,
       errorMessageId,
     });
+
   if (userName.length < 3) return fail('onboarding.signUp.error.userNameShort');
+
   if (userName.length > 30) return fail('onboarding.signUp.error.userNameLong');
+
   if (password.length < 5) return fail('onboarding.signUp.error.passwordShort');
+
   if (password.length > 30) return fail('onboarding.signUp.error.passwordLong');
+
   return pipe(
     isUserNameFree(userName),
     TE.fold(

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -7,6 +7,7 @@ import * as http from '../lib/http';
 import * as config from './config';
 
 type ApiLoginToken = t.TypeOf<typeof tokenType>;
+
 const tokenType = t.strict({
   scopes: t.intersection([
     t.strict({

--- a/src/api/buddies.ts
+++ b/src/api/buddies.ts
@@ -8,6 +8,7 @@ import * as config from './config';
 import * as authApi from './auth';
 
 type ApiBuddy = t.TypeOf<typeof buddyType>;
+
 const buddyType = t.intersection([
   t.strict({
     display_name: t.string,
@@ -39,6 +40,7 @@ export function fetchBuddies(
     ({ resources }) =>
       resources.reduce((acc, apiBuddy) => {
         const buddy = toBuddy(apiBuddy);
+
         return { ...acc, [buddy.buddyId]: buddy };
       }, {}),
   );

--- a/src/api/mentors.ts
+++ b/src/api/mentors.ts
@@ -7,6 +7,7 @@ import * as http from '../lib/http';
 import * as config from './config';
 
 type ApiMentor = t.TypeOf<typeof mentorType>;
+
 const mentorType = t.strict({
   user_id: t.string,
   birth_year: t.number,
@@ -19,6 +20,7 @@ const mentorType = t.strict({
 const mentorListType = t.strict({ resources: t.array(mentorType) });
 
 export type Mentor = ReturnType<typeof toMentor>;
+
 const toMentor = ({
   birth_year,
   display_name,
@@ -32,9 +34,11 @@ const toMentor = ({
 });
 
 export type Mentors = Record<string, Mentor>;
+
 const fromMentorList = ({ resources }: t.TypeOf<typeof mentorListType>) =>
   resources.reduce((acc: Mentors, apiMentor) => {
     const mentor = toMentor(apiMentor);
+
     return { ...acc, [mentor.buddyId]: mentor };
   }, {});
 
@@ -53,12 +57,15 @@ export function compareLang(a: Mentor, b: Mentor) {
 
   const lang = 'Italian';
   const hasLang = ({ languages }: Mentor) => languages.includes(lang);
+
   if (hasLang(a) && !hasLang(b)) {
     return -1;
   }
+
   if (!hasLang(a) && hasLang(b)) {
     return 1;
   }
+
   return 0;
 }
 

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -12,6 +12,7 @@ import * as authApi from './auth';
 import * as config from './config';
 
 type ApiMessage = t.TypeOf<typeof messageType>;
+
 const messageType = t.interface({
   content: t.string,
   recipient_id: t.string,
@@ -24,6 +25,7 @@ const messageType = t.interface({
 export const markSeen = (message: Message) => (token: authApi.AccessToken) => {
   const url = `${config.baseUrl}/users/${token.userId}/messages/${message.messageId}`;
   const seenMessage = messageType.encode(toApiMessage(token.userId, message));
+
   return http.validateResponse(
     http.put(url, seenMessage, {
       headers: authApi.authHeader(token),
@@ -60,6 +62,7 @@ export type Message = {
 const toMessage: (a: string) => (b: ApiMessage) => Message =
   userId => apiMessage => {
     const isSent = userId === apiMessage.sender_id;
+
     return {
       type: isSent ? 'Sent' : 'Received',
       buddyId: isSent ? apiMessage.recipient_id : apiMessage.sender_id,
@@ -102,12 +105,14 @@ export const sendMessage =
   (params: SendMessageParams) =>
   (accessToken: authApi.AccessToken): TE.TaskEither<string, undefined> => {
     const url = `${config.baseUrl}/users/${accessToken.userId}/messages`;
+
     const message = {
       sender_id: accessToken.userId,
       recipient_id: params.buddyId,
       content: params.text,
       opened: false,
     };
+
     return pipe(
       http.post(url, message, {
         headers: authApi.authHeader(accessToken),

--- a/src/api/token-storage.ts
+++ b/src/api/token-storage.ts
@@ -11,6 +11,7 @@ import * as auth from './auth';
 const key = 'LOGIN';
 
 type StorableToken = t.TypeOf<typeof storableTokenType>;
+
 const storableTokenType = t.strict({
   scopes: t.strict({
     accountId: t.string,

--- a/src/lib/use-layout.ts
+++ b/src/lib/use-layout.ts
@@ -14,9 +14,11 @@ export default function (): [
     width: 0,
     height: 0,
   });
+
   const onLayout = (event: RN.LayoutChangeEvent) => {
     const { width, height } = event.nativeEvent.layout;
     setLayout({ width, height });
   };
+
   return [layout, onLayout];
 }

--- a/src/lib/use-remote-data.ts
+++ b/src/lib/use-remote-data.ts
@@ -21,6 +21,7 @@ function useRemoteData<Args extends any[], Err, Value>(
   const [request, setRequest] = React.useState<RequestState<Args>>({
     type: 'idle',
   });
+
   const [state, setState] = React.useState<RD.RemoteData<Err, Value>>(
     RD.initial,
   );
@@ -30,6 +31,7 @@ function useRemoteData<Args extends any[], Err, Value>(
       setState(RD.pending);
       (async () => {
         const newState = await apiCall(...request.args)();
+
         if (request.type === 'waiting') {
           setState(RD.fromEither(newState));
           setRequest({ type: 'idle' });
@@ -37,6 +39,7 @@ function useRemoteData<Args extends any[], Err, Value>(
       })();
     }
   }, [request.type]);
+
   return [
     state,
     (...args: Args) => {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -8,6 +8,7 @@ export const unixTimeFromDateString = new t.Type<number, string, unknown>(
   (u, c) =>
     either.chain(t.string.validate(u, c), s => {
       const n = new Date(s).getTime();
+
       return isNaN(n) ? t.failure(u, c) : t.success(n);
     }),
   a => new Date(a).toISOString(),

--- a/src/localization/index.ts
+++ b/src/localization/index.ts
@@ -11,6 +11,7 @@ export type MessageId = fi.MessageId;
 type Language = 'fi' | 'en';
 
 const lang: Language = isFinnishPhone ? 'fi' : 'en';
+
 const messages = {
   fi: fi.messages,
   en: en.messages,

--- a/src/state/middleware/index.ts
+++ b/src/state/middleware/index.ts
@@ -23,7 +23,9 @@ export const taskRunner =
   (action: redux.Action | Cmd) => {
     if (isCmd(action)) {
       const { task } = action;
+
       return task().then(resultAction => dispatch(resultAction));
     }
+
     return next(action);
   };

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -33,6 +33,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
             const requiredBuddies = set.fromArray(Eq.eqString)(
               record.keys(messages),
             );
+
             const hasAllBuddies = pipe(
               state,
               RD.map(record.keys),
@@ -42,6 +43,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
               ),
               RD.getOrElse(() => false),
             );
+
             return hasAllBuddies
               ? state
               : automaton.loop(

--- a/src/state/reducers/changeEmail.ts
+++ b/src/state/reducers/changeEmail.ts
@@ -47,6 +47,7 @@ export const reducer: automaton.Reducer<
       if (!RD.isInitial(state)) {
         return state;
       }
+
       return automaton.loop(
         RD.pending,
         withToken(
@@ -63,6 +64,7 @@ export const reducer: automaton.Reducer<
       if (RD.isPending(state)) {
         return state;
       }
+
       return RD.initial;
     default:
       return state;

--- a/src/state/reducers/changePassword.ts
+++ b/src/state/reducers/changePassword.ts
@@ -24,6 +24,7 @@ export const reducer: automaton.Reducer<
       if (!remoteData.isInitial(state)) {
         return state;
       }
+
       return automaton.loop(
         remoteData.pending,
         withToken(
@@ -46,6 +47,7 @@ export const reducer: automaton.Reducer<
       if (remoteData.isPending(state)) {
         return state;
       }
+
       return remoteData.initial;
     default:
       return state;

--- a/src/state/reducers/markSeen.ts
+++ b/src/state/reducers/markSeen.ts
@@ -17,10 +17,13 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     case 'messages/markSeen':
       const message = action.payload.message;
       const id = message.messageId;
+
       if (id in state || message.isSeen || message.type === 'Sent') {
         return state;
       }
+
       const markSeenTask = api.markSeen(action.payload.message);
+
       return automaton.loop(
         { ...state, [id]: true },
         withToken(markSeenTask, () => ({

--- a/src/state/reducers/mentors.ts
+++ b/src/state/reducers/mentors.ts
@@ -59,12 +59,14 @@ export function getActiveFilters({
   skillFilter,
 }: types.AppState): ActiveFilters {
   const amount = skillFilter.length;
+
   if (amount === 0) {
     return {
       kind: 'NoFilters',
       message: localization.trans('main.mentorsTitleAndSearchButton'),
     };
   }
+
   return {
     kind: 'FiltersActive',
     message: `${localization.trans(
@@ -75,6 +77,7 @@ export function getActiveFilters({
 
 export const getSkillList = (state: types.AppState) => {
   const remoteDataMentorList = get(state);
+
   return pipe(
     remoteDataMentorList,
     RD.getOrElse<unknown, mentorsApi.Mentor[]>(() => []),

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -44,6 +44,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       if (!state.polling) {
         return state;
       }
+
       const nextState = {
         ...state,
         messages: RD.remoteData.alt(
@@ -56,6 +57,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
         flow(messageApi.fetchMessages, T.delay(config.messageFetchDelay)),
         actions.make('messages/get/completed'),
       );
+
       return automaton.loop(nextState, nextCmd);
     }
     default:
@@ -121,6 +123,7 @@ export const getOrder: (
     record.map(messagesById => {
       const messages = Object.values(messagesById).sort(ordMessage.compare);
       const last = messages[messages.length - 1];
+
       return last.sentTime;
     }),
   ),

--- a/src/state/reducers/storage.ts
+++ b/src/state/reducers/storage.ts
@@ -37,9 +37,11 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     case 'storage/readToken/end': {
       const nextState = { ...state, readToken: RD.fromEither(action.payload) };
       const token = O.toNullable(O.fromEither(action.payload));
+
       if (!token) {
         return nextState;
       }
+
       return automaton.loop(nextState, actions.make('token/Acquired')(token));
     }
     case 'storage/writeToken/start': {

--- a/src/state/reducers/userAccount.ts
+++ b/src/state/reducers/userAccount.ts
@@ -24,6 +24,7 @@ export const reducer: automaton.Reducer<
       if (RD.isPending(state)) {
         return state;
       }
+
       return automaton.loop(
         RD.pending,
         withToken(

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -41,9 +41,11 @@ export const getBuddyName = (
 ) => {
   const look = (fa: RD.RemoteData<unknown, Record<string, { name: string }>>) =>
     RD.remoteData.map(fa, a => record.lookup(buddyId, a));
+
   const buddy = getOptionM(RD.remoteData).alt(look(buddyState), () =>
     look(mentorState),
   );
+
   return getFoldableComposition(RD.remoteData, O.option).reduce(
     buddy,
     '',
@@ -67,6 +69,7 @@ const messageList = (messageState: AppState['messages'], buddyId: string) => {
   const messagesById = RD.remoteData.map(messageState.messages, r =>
     record.lookup(buddyId, r),
   );
+
   return getFoldableComposition(RD.remoteData, O.option).reduce<
     string,
     Record<string, messageApi.Message>,


### PR DESCRIPTION
What was changed?

I added Eslint rule to require empty line before

- return statement
- if block
- multiline let/const

Why?

By adding empty lines before those you see "logical structure" of the code with just a glance. I find it much easier to read code that has been formatted this way. Also this ensures consistency in code base. Consistency is golden.