### PR TITLE
Use correct view in change password e2e test

### DIFF
--- a/e2e/changePasswordTest.spec.ts
+++ b/e2e/changePasswordTest.spec.ts
@@ -35,7 +35,7 @@ describe('changePassword', () => {
 
     await scrollUpTo(
       'main.settings.account.password.current',
-      'main.settings.index.view',
+      'main.settings.password.view',
     );
 
     await waitAndTypeText(
@@ -53,7 +53,7 @@ describe('changePassword', () => {
 
     await scrollDownAndTap(
       'main.settings.account.password.save',
-      'main.settings.index.view',
+      'main.settings.password.view',
     );
 
     await forceLogout();


### PR DESCRIPTION
Change password feature is in it's own view now, so update e2e test to use new view too.