### PR TITLE
Fix emailChange- and passwordChange-state after change

### DIFF
--- a/e2e/changeEmailTest.spec.ts
+++ b/e2e/changeEmailTest.spec.ts
@@ -30,7 +30,6 @@ describe('changeEmail', () => {
     await waitAndTypeText('main.settings.account.email.input', newEmail + '\n');
 
     await element(by.id('main.settings.account.email.save')).tap();
-    await element(by.id('main.settings.account.email.cancel')).tap();
     await expect(element(by.text(newEmail))).toBeVisible();
   });
 });

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -61,6 +61,15 @@ export default ({ navigation }: Props) => {
 
       return () => clearTimeout(timeout);
     }
+
+    if (RD.isFailure(requestState)) {
+      const timeout = setTimeout(
+        dispatch(changeEmailState.resetChangeEmail),
+        changeEmailState.coolDownDuration,
+      );
+
+      return () => clearTimeout(timeout);
+    }
   }, [requestState]);
 
   return (

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -22,6 +22,7 @@ import Spinner from '../../components/Spinner';
 import { MentorListRoute } from '../../Onboarding/MentorList';
 
 import AlertBox from './UserAccount/AlertBox';
+import AlertDialog from './UserAccount/AlertDialog';
 import EmailForm from 'src/Screens/components/EmailForm';
 
 export type EmailChangeRoute = {
@@ -43,6 +44,12 @@ export default ({ navigation }: Props) => {
   const onButtonPress = () => {
     dispatch(changeEmailState.changeEmail({ email, account: account }));
   };
+
+  const tryAgain = () => {
+    dispatch(changeEmailState.resetChangeEmail);
+    dispatch(changeEmailState.changeEmail({ email, account: account }));
+  };
+
   const requestState = useSelector(changeEmailState.select);
 
   const resetAndGoBack = () => {
@@ -50,16 +57,12 @@ export default ({ navigation }: Props) => {
     onGoBack();
   };
 
-  const isRequestResolved =
-    RD.isSuccess(requestState) || RD.isFailure(requestState);
-
   React.useEffect(() => {
-    if (isRequestResolved) {
-      const callBack = RD.isSuccess(requestState)
-        ? resetAndGoBack
-        : dispatch(changeEmailState.resetChangeEmail);
-
-      const timeout = setTimeout(callBack, changeEmailState.coolDownDuration);
+    if (RD.isSuccess(requestState)) {
+      const timeout = setTimeout(
+        resetAndGoBack,
+        changeEmailState.coolDownDuration,
+      );
 
       return () => clearTimeout(timeout);
     }
@@ -100,11 +103,11 @@ export default ({ navigation }: Props) => {
               ),
               () => <Spinner style={styles.spinner} />,
               () => (
-                <AlertBox
+                <AlertDialog
                   imageStyle={styles.failBox}
                   imageSource={require('../../images/alert-circle.svg')}
-                  duration={changeEmailState.coolDownDuration}
                   messageId="main.settings.account.email.fail"
+                  tryAgainCallback={tryAgain}
                 />
               ),
               () => (

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -107,7 +107,7 @@ export default ({ navigation }: Props) => {
                   imageStyle={styles.failBox}
                   imageSource={require('../../images/alert-circle.svg')}
                   messageId="main.settings.account.email.fail"
-                  tryAgainCallback={tryAgain}
+                  onPress={tryAgain}
                 />
               ),
               () => (

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -45,28 +45,19 @@ export default ({ navigation }: Props) => {
   };
   const requestState = useSelector(changeEmailState.select);
 
-  const goBackAndResetEmailChangeState = () => {
+  const resetAndGoBack = (value: string | undefined) => {
+    setEmail(value ?? '');
     dispatch(changeEmailState.resetChangeEmail);
     onGoBack();
   };
 
   React.useEffect(() => {
-    if (RD.isSuccess(requestState)) {
-      setEmail(requestState.value.email ?? '');
+    if (!RD.isPending(requestState) && !RD.isInitial(requestState)) {
+      const callBack = RD.isSuccess(requestState)
+        ? resetAndGoBack(requestState.value?.email)
+        : dispatch(changeEmailState.resetChangeEmail);
 
-      const timeout = setTimeout(
-        goBackAndResetEmailChangeState,
-        changeEmailState.coolDownDuration,
-      );
-
-      return () => clearTimeout(timeout);
-    }
-
-    if (RD.isFailure(requestState)) {
-      const timeout = setTimeout(
-        dispatch(changeEmailState.resetChangeEmail),
-        changeEmailState.coolDownDuration,
-      );
+      const timeout = setTimeout(callBack, changeEmailState.coolDownDuration);
 
       return () => clearTimeout(timeout);
     }

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -45,19 +45,18 @@ export default ({ navigation }: Props) => {
   };
   const requestState = useSelector(changeEmailState.select);
 
-  const resetAndGoBack = (value: string | undefined) => {
-    setEmail(value ?? '');
+  const resetAndGoBack = () => {
     dispatch(changeEmailState.resetChangeEmail);
     onGoBack();
   };
 
-  const changeIsResolved =
+  const isRequestResolved =
     RD.isSuccess(requestState) || RD.isFailure(requestState);
 
   React.useEffect(() => {
-    if (changeIsResolved) {
+    if (isRequestResolved) {
       const callBack = RD.isSuccess(requestState)
-        ? () => resetAndGoBack(requestState.value?.email)
+        ? resetAndGoBack
         : dispatch(changeEmailState.resetChangeEmail);
 
       const timeout = setTimeout(callBack, changeEmailState.coolDownDuration);

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -51,10 +51,13 @@ export default ({ navigation }: Props) => {
     onGoBack();
   };
 
+  const changeIsResolved =
+    RD.isSuccess(requestState) || RD.isFailure(requestState);
+
   React.useEffect(() => {
-    if (!RD.isPending(requestState) && !RD.isInitial(requestState)) {
+    if (changeIsResolved) {
       const callBack = RD.isSuccess(requestState)
-        ? resetAndGoBack(requestState.value?.email)
+        ? () => resetAndGoBack(requestState.value?.email)
         : dispatch(changeEmailState.resetChangeEmail);
 
       const timeout = setTimeout(callBack, changeEmailState.coolDownDuration);

--- a/src/Screens/Main/Settings/Email.tsx
+++ b/src/Screens/Main/Settings/Email.tsx
@@ -45,10 +45,19 @@ export default ({ navigation }: Props) => {
   };
   const requestState = useSelector(changeEmailState.select);
 
+  const goBackAndResetEmailChangeState = () => {
+    dispatch(changeEmailState.resetChangeEmail);
+    onGoBack();
+  };
+
   React.useEffect(() => {
     if (RD.isSuccess(requestState)) {
       setEmail(requestState.value.email ?? '');
-      const timeout = setTimeout(onGoBack, changeEmailState.coolDownDuration);
+
+      const timeout = setTimeout(
+        goBackAndResetEmailChangeState,
+        changeEmailState.coolDownDuration,
+      );
 
       return () => clearTimeout(timeout);
     }

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -64,8 +64,11 @@ export default ({ navigation }: Props) => {
 
   const requestState = useSelector(state.select);
 
+  const changeIsResolved =
+    RD.isSuccess(requestState) || RD.isFailure(requestState);
+
   React.useEffect(() => {
-    if (!RD.isPending(requestState) && !RD.isInitial(requestState)) {
+    if (changeIsResolved) {
       const callBack = RD.isSuccess(requestState)
         ? resetAndGoBack
         : dispatch(state.reset);

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -122,7 +122,7 @@ export default ({ navigation }: Props) => {
                   imageStyle={styles.failBox}
                   imageSource={require('../../images/alert-circle.svg')}
                   messageId="main.settings.account.password.failure"
-                  tryAgainCallback={tryAgain}
+                  onPress={tryAgain}
                 />
               ),
               () => (

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -50,6 +50,11 @@ export default ({ navigation }: Props) => {
     navigation.goBack();
   };
 
+  const goBackAndResetPasswordChangeState = () => {
+    dispatch(state.reset);
+    onGoBack();
+  };
+
   const onButtonPress = () => {
     dispatch(state.changePassword({ currentPassword, newPassword }));
   };
@@ -60,7 +65,10 @@ export default ({ navigation }: Props) => {
       setCurrentPassword('');
       setNewPassword('');
       setRepeatedNewPassword('');
-      const timeout = setTimeout(onGoBack, state.coolDownDuration);
+      const timeout = setTimeout(
+        goBackAndResetPasswordChangeState,
+        state.coolDownDuration,
+      );
 
       return () => clearTimeout(timeout);
     }

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -46,36 +46,31 @@ export default ({ navigation }: Props) => {
     repeatedNewPassword.length > 0 &&
     newPassword === repeatedNewPassword;
 
+  const onButtonPress = () => {
+    dispatch(state.changePassword({ currentPassword, newPassword }));
+  };
+
   const onGoBack = () => {
     navigation.goBack();
   };
 
-  const goBackAndResetPasswordChangeState = () => {
+  const resetAndGoBack = () => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setRepeatedNewPassword('');
     dispatch(state.reset);
     onGoBack();
   };
 
-  const onButtonPress = () => {
-    dispatch(state.changePassword({ currentPassword, newPassword }));
-  };
   const requestState = useSelector(state.select);
 
   React.useEffect(() => {
-    if (RD.isSuccess(requestState)) {
-      setCurrentPassword('');
-      setNewPassword('');
-      setRepeatedNewPassword('');
+    if (!RD.isPending(requestState) && !RD.isInitial(requestState)) {
+      const callBack = RD.isSuccess(requestState)
+        ? resetAndGoBack
+        : dispatch(state.reset);
 
-      const timeout = setTimeout(
-        goBackAndResetPasswordChangeState,
-        state.coolDownDuration,
-      );
-
-      return () => clearTimeout(timeout);
-    }
-
-    if (RD.isFailure(requestState)) {
-      const timeout = setTimeout(dispatch(state.reset), state.coolDownDuration);
+      const timeout = setTimeout(callBack, state.coolDownDuration);
 
       return () => clearTimeout(timeout);
     }

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -21,6 +21,7 @@ import Spinner from '../../components/Spinner';
 import { MentorListRoute } from '../../Onboarding/MentorList';
 
 import AlertBox from './UserAccount/AlertBox';
+import AlertDialog from './UserAccount/AlertDialog';
 import PasswordForm from 'src/Screens/components/PasswordForm';
 
 export type PasswordChangeRoute = {
@@ -59,18 +60,16 @@ export default ({ navigation }: Props) => {
     onGoBack();
   };
 
+  const tryAgain = () => {
+    dispatch(state.reset);
+    dispatch(state.changePassword({ currentPassword, newPassword }));
+  };
+
   const requestState = useSelector(state.select);
 
-  const isRequestResolved =
-    RD.isSuccess(requestState) || RD.isFailure(requestState);
-
   React.useEffect(() => {
-    if (isRequestResolved) {
-      const callBack = RD.isSuccess(requestState)
-        ? resetAndGoBack
-        : dispatch(state.reset);
-
-      const timeout = setTimeout(callBack, state.coolDownDuration);
+    if (RD.isSuccess(requestState)) {
+      const timeout = setTimeout(resetAndGoBack, state.coolDownDuration);
 
       return () => clearTimeout(timeout);
     }
@@ -119,11 +118,11 @@ export default ({ navigation }: Props) => {
               ),
               () => <Spinner style={styles.spinner} />,
               () => (
-                <AlertBox
+                <AlertDialog
                   imageStyle={styles.failBox}
                   imageSource={require('../../images/alert-circle.svg')}
-                  duration={state.coolDownDuration}
                   messageId="main.settings.account.password.failure"
+                  tryAgainCallback={tryAgain}
                 />
               ),
               () => (

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -55,20 +55,17 @@ export default ({ navigation }: Props) => {
   };
 
   const resetAndGoBack = () => {
-    setCurrentPassword('');
-    setNewPassword('');
-    setRepeatedNewPassword('');
     dispatch(state.reset);
     onGoBack();
   };
 
   const requestState = useSelector(state.select);
 
-  const changeIsResolved =
+  const isRequestResolved =
     RD.isSuccess(requestState) || RD.isFailure(requestState);
 
   React.useEffect(() => {
-    if (changeIsResolved) {
+    if (isRequestResolved) {
       const callBack = RD.isSuccess(requestState)
         ? resetAndGoBack
         : dispatch(state.reset);

--- a/src/Screens/Main/Settings/Password.tsx
+++ b/src/Screens/Main/Settings/Password.tsx
@@ -65,10 +65,17 @@ export default ({ navigation }: Props) => {
       setCurrentPassword('');
       setNewPassword('');
       setRepeatedNewPassword('');
+
       const timeout = setTimeout(
         goBackAndResetPasswordChangeState,
         state.coolDownDuration,
       );
+
+      return () => clearTimeout(timeout);
+    }
+
+    if (RD.isFailure(requestState)) {
+      const timeout = setTimeout(dispatch(state.reset), state.coolDownDuration);
 
       return () => clearTimeout(timeout);
     }

--- a/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
+++ b/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
@@ -14,7 +14,7 @@ type Props = {
   style?: RN.StyleProp<RN.ViewStyle>;
   imageStyle?: RN.StyleProp<RN.ImageStyle>;
   messageId: localization.MessageId;
-  tryAgainCallback: () => void;
+  onPress: () => void;
 };
 
 export default (props: Props) => {
@@ -26,7 +26,7 @@ export default (props: Props) => {
       />
       <Message id={props.messageId} style={styles.text} />
       <Button
-        onPress={props.tryAgainCallback}
+        onPress={props.onPress}
         messageStyle={styles.retryButtonText}
         messageId="components.remoteData.retry"
         style={{ backgroundColor: colors.blue }}

--- a/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
+++ b/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import RN from 'react-native';
+
+import * as localization from '../../../../localization';
+
+import Message from '../../../components/Message';
+import Button from '../../../components/Button';
+import colors from '../../../components/colors';
+import fonts from '../../../components/fonts';
+import { textShadow } from '../../../components/shadow';
+
+type Props = {
+  imageSource: RN.ImageSourcePropType;
+  style?: RN.StyleProp<RN.ViewStyle>;
+  imageStyle?: RN.StyleProp<RN.ImageStyle>;
+  messageId: localization.MessageId;
+  tryAgainCallback: () => void;
+};
+
+export default (props: Props) => {
+  return (
+    <RN.View style={[styles.container, props.style]}>
+      <RN.Image
+        style={[styles.image, props.imageStyle]}
+        source={props.imageSource}
+      />
+      <Message id={props.messageId} style={styles.text} />
+      <Button
+        onPress={props.tryAgainCallback}
+        messageStyle={styles.retryButtonText}
+        messageId="components.remoteData.retry"
+        style={{ backgroundColor: colors.blue }}
+      />
+    </RN.View>
+  );
+};
+
+const styles = RN.StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 24,
+    padding: 24,
+  },
+  text: {
+    color: colors.darkestBlue,
+    ...fonts.largeBold,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  image: {
+    width: 160,
+    height: 160,
+    tintColor: colors.darkestBlue,
+    marginBottom: 40,
+  },
+  retryButtonText: {
+    color: colors.white,
+    ...fonts.largeBold,
+    ...textShadow,
+  },
+});

--- a/src/state/reducers/changeEmail.ts
+++ b/src/state/reducers/changeEmail.ts
@@ -63,6 +63,7 @@ export const reducer: automaton.Reducer<
       }
 
       return RD.initial;
+
     default:
       return state;
   }

--- a/src/state/reducers/changeEmail.ts
+++ b/src/state/reducers/changeEmail.ts
@@ -2,7 +2,6 @@ import * as automaton from 'redux-automaton';
 import * as O from 'fp-ts/lib/Option';
 import * as RD from '@devexperts/remote-data-ts';
 import * as TE from 'fp-ts/lib/TaskEither';
-import * as T from 'fp-ts/lib/Task';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import * as authApi from '../../api/auth';
@@ -11,7 +10,6 @@ import * as accountApi from '../../api/account';
 import * as actions from '../actions';
 
 import { AppState } from '../types';
-import { cmd } from '../middleware';
 import { withToken } from './accessToken';
 
 export const changeEmail = actions.make('changeEmail/start');
@@ -55,11 +53,10 @@ export const reducer: automaton.Reducer<
           actions.make('changeEmail/completed'),
         ),
       );
+
     case 'changeEmail/completed':
-      return automaton.loop(
-        RD.fromEither(action.payload),
-        cmd(pipe(T.of(resetChangeEmail), T.delay(coolDownDuration))),
-      );
+      return RD.fromEither(action.payload);
+
     case 'changeEmail/reset':
       if (RD.isPending(state)) {
         return state;

--- a/src/state/reducers/changePassword.ts
+++ b/src/state/reducers/changePassword.ts
@@ -1,7 +1,5 @@
 import * as automaton from 'redux-automaton';
 import * as remoteData from '@devexperts/remote-data-ts';
-import * as T from 'fp-ts/lib/Task';
-import { pipe } from 'fp-ts/lib/pipeable';
 
 import * as authApi from '../../api/auth';
 
@@ -9,9 +7,9 @@ import * as actions from '../actions';
 
 import { AppState } from '../types';
 import { withToken } from './accessToken';
-import { cmd } from '../middleware';
 
 export const changePassword = actions.make('changePassword/start');
+export const reset = actions.make('changePassword/reset')(undefined);
 export const initialState = remoteData.initial;
 export const coolDownDuration = 5000;
 
@@ -33,16 +31,8 @@ export const reducer: automaton.Reducer<
         ),
       );
     case 'changePassword/completed':
-      return automaton.loop(
-        remoteData.fromEither(action.payload),
-        cmd(
-          pipe(
-            T.of(undefined),
-            T.map(actions.make('changePassword/reset')),
-            T.delay(coolDownDuration),
-          ),
-        ),
-      );
+      return remoteData.fromEither(action.payload);
+
     case 'changePassword/reset':
       if (remoteData.isPending(state)) {
         return state;

--- a/src/state/reducers/changePassword.ts
+++ b/src/state/reducers/changePassword.ts
@@ -30,6 +30,7 @@ export const reducer: automaton.Reducer<
           actions.make('changePassword/completed'),
         ),
       );
+
     case 'changePassword/completed':
       return remoteData.fromEither(action.payload);
 
@@ -39,6 +40,7 @@ export const reducer: automaton.Reducer<
       }
 
       return remoteData.initial;
+
     default:
       return state;
   }


### PR DESCRIPTION
## Inconsistent state after email is changed

Problem: After editing email address in settings and pressing Save button (and waiting for animation to pass) the next view should be Settings view but instead it is sometimes back to editing view. This happens somewhat randomly when testing manually or running detox.

### approach

Don't reset state in reducer, but in the UI-view