### PR TITLE
Fix title and search button alignment

### DIFF
--- a/src/Screens/Main/MentorList.tsx
+++ b/src/Screens/Main/MentorList.tsx
@@ -55,7 +55,6 @@ const MentorList = (props: Props) => {
 const styles = RN.StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
   },
   title: {
     marginTop: 24,

--- a/src/Screens/components/MentorsTitleAndSearchButton.tsx
+++ b/src/Screens/components/MentorsTitleAndSearchButton.tsx
@@ -49,7 +49,9 @@ export default MentorsTitleAndSearchButton;
 
 const styles = RN.StyleSheet.create({
   container: {
+    paddingHorizontal: 32,
     flexDirection: 'row',
+    justifyContent: 'space-between',
   },
   filterButton: {
     backgroundColor: colors.darkestBlue,


### PR DESCRIPTION
Change the title and search button positioning on mentor list to be aligned with the mentor card. Previously the position was centered.

Picture of how it looks on Android:
<img src="https://user-images.githubusercontent.com/36920208/123236350-64e10580-d4e5-11eb-85d1-e8a8922e2b69.png" width=50% height=50%>
