### PR TITLE
Fix buddieReducer state after banning

### DIFF
--- a/src/Screens/Main/BannedList/index.tsx
+++ b/src/Screens/Main/BannedList/index.tsx
@@ -19,7 +19,7 @@ import { Title } from './Title';
 
 import colors from '../../components/colors';
 import RemoteData from '../../components/RemoteData';
-import { BanActions } from 'src/api/buddies';
+import { BanAction } from 'src/api/buddies';
 
 export type BannedListRoute = {
   'Main/BannedList': {};
@@ -49,7 +49,7 @@ export default ({ navigation }: Props) => {
 
   const dispatch = ReactRedux.useDispatch<redux.Dispatch<actions.Action>>();
 
-  const handleBatchBan = (banStatus: BanActions) => {
+  const handleBatchBan = (banStatus: BanAction) => {
     setDialogState({ dropdownOpen: false, dialogOpen: false });
 
     if (RD.isSuccess(remoteBuddies) && remoteBuddies.value?.length) {

--- a/src/Screens/Main/Chat/index.tsx
+++ b/src/Screens/Main/Chat/index.tsx
@@ -16,7 +16,7 @@ import DropDown, { DropDownItem } from '../../components/DropDownMenu';
 import { Dialog, DialogProps } from '../../components/Dialog';
 
 import colors from '../../components/colors';
-import { BanActions } from 'src/api/buddies';
+import { BanAction } from 'src/api/buddies';
 
 export type ChatRoute = {
   'Main/Chat': { buddyId: string };
@@ -49,14 +49,14 @@ const Chat = ({ navigation }: Props) => {
 
   const dispatch = ReactRedux.useDispatch<redux.Dispatch<actions.Action>>();
 
-  const setBanStatus = (banStatus: BanActions) => {
+  const setBanStatus = (banStatus: BanAction) => {
     dispatch({
       type: 'buddies/changeBanStatus/start',
       payload: { buddyId, banStatus },
     });
   };
 
-  const handleBan = (banStatus: BanActions) => {
+  const handleBan = (banStatus: BanAction) => {
     setDialogState({ dropdownOpen: false, dialogOpen: false });
     goBack();
     setBanStatus(banStatus);

--- a/src/api/buddies.ts
+++ b/src/api/buddies.ts
@@ -49,6 +49,7 @@ const mappedStatuses: MappedStatuses = {
   Unban: 'ok',
   Delete: 'deleted',
 };
+
 const mappedFromApi: MappedStatusesFromApi = {
   banned: 'Banned',
   deleted: 'Deleted',

--- a/src/api/buddies.ts
+++ b/src/api/buddies.ts
@@ -43,10 +43,10 @@ const toApiBanStatus = {
 };
 
 const toBanStatus = {
-  banned: 'Banned' as BanStatus,
-  deleted: 'Deleted' as BanStatus,
-  ok: 'NotBanned' as BanStatus,
-};
+  banned: 'Banned',
+  deleted: 'Deleted',
+  ok: 'NotBanned',
+} as const;
 
 const toBuddy = ({ id, display_name, status = 'ok' }: ApiBuddy): Buddy => ({
   buddyId: id,

--- a/src/api/buddies.ts
+++ b/src/api/buddies.ts
@@ -14,7 +14,13 @@ const buddyType = t.intersection([
     display_name: t.string,
     id: t.string,
   }),
-  t.partial({ status: t.literal('banned') }),
+  t.partial({
+    status: t.union([
+      t.literal('banned'),
+      t.literal('deleted'),
+      t.literal('ok'),
+    ]),
+  }),
 ]);
 
 const buddiesType = t.strict({ resources: t.array(buddyType) });
@@ -25,6 +31,9 @@ export type BanStatusStrings = 'banned' | 'ok' | 'deleted';
 
 type MappedStatuses = {
   [Action in BanActions]: BanStatusStrings;
+};
+type MappedStatusesFromApi = {
+  [K in BanStatusStrings]: BanStatuses;
 };
 
 export type Buddy = {
@@ -40,11 +49,16 @@ const mappedStatuses: MappedStatuses = {
   Unban: 'ok',
   Delete: 'deleted',
 };
+const mappedFromApi: MappedStatusesFromApi = {
+  banned: 'Banned',
+  deleted: 'Deleted',
+  ok: 'NotBanned',
+};
 
 const toBuddy = ({ id, display_name, status }: ApiBuddy): Buddy => ({
   buddyId: id,
   name: display_name,
-  status: status === 'banned' ? 'Banned' : 'NotBanned',
+  status: status ? mappedFromApi[status] : 'NotBanned',
 });
 
 const toBuddies = ({ resources }: t.TypeOf<typeof buddiesType>) =>

--- a/src/state/actions/regular.ts
+++ b/src/state/actions/regular.ts
@@ -82,7 +82,7 @@ type RegularActions = {
     banStatus: buddyApi.BanActions;
   };
   'buddies/changeBanStatusBatch/end': E.Either<string, buddyApi.Buddies>;
-  'buddies/changeStatus/end': E.Either<string, buddyApi.Buddy>;
+  'buddies/changeBanStatus/end': E.Either<string, buddyApi.Buddy>;
 
   'newMessage/send/start': messageApi.SendMessageParams;
   'newMessage/send/end': {

--- a/src/state/actions/regular.ts
+++ b/src/state/actions/regular.ts
@@ -75,11 +75,11 @@ type RegularActions = {
   'buddies/completed': Result<typeof buddyApi.fetchBuddies>;
   'buddies/changeBanStatus/start': {
     buddyId: string;
-    banStatus: buddyApi.BanActions;
+    banStatus: buddyApi.BanAction;
   };
   'buddies/changeBanStatusBatch/start': {
     buddyIds: string[];
-    banStatus: buddyApi.BanActions;
+    banStatus: buddyApi.BanAction;
   };
   'buddies/changeBanStatusBatch/end': E.Either<string, buddyApi.Buddies>;
   'buddies/changeBanStatus/end': E.Either<string, buddyApi.Buddy>;

--- a/src/state/reducers/banBuddyRequest.ts
+++ b/src/state/reducers/banBuddyRequest.ts
@@ -37,6 +37,28 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       );
     }
 
+    case 'buddies/changeBanStatusBatch/start':
+      return automaton.loop(
+        RD.pending,
+        withToken(
+          buddyApi.banBuddies(
+            action.payload.buddyIds,
+            action.payload.banStatus,
+          ),
+          actions.make('buddies/changeBanStatusBatch/end'),
+        ),
+      );
+
+    case 'buddies/changeBanStatusBatch/end': {
+      return pipe(
+        action.payload,
+        E.fold(
+          fail => automaton.loop<State, actions.Action>(RD.failure(fail)),
+          _ => automaton.loop(RD.success(undefined)),
+        ),
+      );
+    }
+
     default: {
       return state;
     }

--- a/src/state/reducers/banBuddyRequest.ts
+++ b/src/state/reducers/banBuddyRequest.ts
@@ -42,3 +42,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     }
   }
 };
+
+export const selectBanBuddyRequest = ({ banBuddyRequest: state }: AppState) =>
+  state;

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -16,6 +16,7 @@ export type State = types.AppState['buddies'];
 
 import { withToken } from './accessToken';
 import * as messageState from './messages';
+import * as banBuddyRequestState from './banBuddyRequest';
 
 export const initialState = RD.initial;
 
@@ -110,7 +111,15 @@ const getBuddiesWithStatus = (status: buddyApi.Buddy['status']) =>
 const getBuddies =
   (status: buddyApi.Buddy['status']) => (appState: types.AppState) => {
     const remoteBuddies = getBuddiesWithStatus(status)(appState);
+
     const remoteBuddyOrder = messageState.getOrder(appState);
+
+    const banBuddyRequest =
+      banBuddyRequestState.selectBanBuddyRequest(appState);
+
+    if (RD.isPending(banBuddyRequest)) {
+      return RD.pending;
+    }
 
     const both = RD.combine(remoteBuddies, remoteBuddyOrder);
 

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -91,7 +91,9 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
 
         const newState = filteredIds.reduce<Record<string, buddyApi.Buddy>>(
           (acc, curr) => {
-            return { ...acc, [curr]: responseBuddies[curr] };
+            const updatedBuddy = responseBuddies[curr] ?? state.value[curr];
+
+            return { ...acc, [curr]: updatedBuddy };
           },
           {},
         );

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -61,22 +61,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     case 'buddies/completed':
       return RD.fromEither(action.payload);
 
-<<<<<<< HEAD
-
-    case 'buddies/changeBanStatusBatch/start':
-      return automaton.loop(
-        RD.pending,
-        withToken(
-          buddyApi.banBuddies(
-            action.payload.buddyIds,
-            action.payload.banStatus,
-          ),
-          actions.make('buddies/changeBanStatusBatch/end'),
-        ),
-      );
-
-=======
->>>>>>> New reducer for banRequest
     case 'buddies/changeBanStatus/end':
       return pipe(
         action.payload,
@@ -92,6 +76,10 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
             ),
         ),
       );
+
+    case 'buddies/changeBanStatusBatch/end':
+      console.log(action.payload);
+      return state;
 
     default:
       return state;

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -78,29 +78,26 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       );
 
     case 'buddies/changeBanStatusBatch/end':
-      if (E.isRight(action.payload)) {
-        const items = action.payload.right;
+      if (E.isRight(action.payload) && RD.isSuccess(state)) {
+        const responseBuddies = action.payload.right;
 
-        const deletedIds = Object.keys(items).filter(
-          key => items[key].status === 'Deleted',
+        const deletedIds = Object.keys(responseBuddies).filter(
+          key => responseBuddies[key].status === 'Deleted',
         );
 
-        if (RD.isSuccess(state)) {
-          const filteredIds = Object.keys(state.value).filter(
-            buddyId => !deletedIds.includes(buddyId),
-          );
+        const filteredIds = Object.keys(state.value).filter(
+          buddyId => !deletedIds.includes(buddyId),
+        );
 
-          const newState = filteredIds.reduce<Record<string, buddyApi.Buddy>>(
-            (acc, curr) => {
-              return { ...acc, [curr]: state.value[curr] };
-            },
-            {},
-          );
+        const newState = filteredIds.reduce<Record<string, buddyApi.Buddy>>(
+          (acc, curr) => {
+            return { ...acc, [curr]: responseBuddies[curr] };
+          },
+          {},
+        );
+        console.log('newState', newState);
 
-          return RD.success(newState);
-        }
-
-        return state;
+        return RD.success(newState);
       }
 
       return state;

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -60,14 +60,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     case 'buddies/completed':
       return RD.fromEither(action.payload);
 
-    case 'buddies/changeBanStatus/start':
-      return automaton.loop(
-        state,
-        withToken(
-          buddyApi.banBuddy(action.payload.buddyId, action.payload.banStatus),
-          actions.make('buddies/changeStatus/end'),
-        ),
-      );
 
     case 'buddies/changeBanStatusBatch/start':
       return automaton.loop(
@@ -81,13 +73,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
         ),
       );
 
-    case 'buddies/changeBanStatusBatch/end':
-      return automaton.loop(
-        RD.pending,
-        withToken(buddyApi.fetchBuddies, actions.make('buddies/completed')),
-      );
-
-    case 'buddies/changeStatus/end':
+    case 'buddies/changeBanStatus/end':
       return pipe(
         action.payload,
         E.fold(

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -56,12 +56,13 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
           },
         ),
       );
+
     case 'buddies/completed':
       return RD.fromEither(action.payload);
 
     case 'buddies/changeBanStatus/start':
       return automaton.loop(
-        RD.pending,
+        state,
         withToken(
           buddyApi.banBuddy(action.payload.buddyId, action.payload.banStatus),
           actions.make('buddies/changeStatus/end'),

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -95,7 +95,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
           },
           {},
         );
-        console.log('newState', newState);
 
         return RD.success(newState);
       }

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -78,7 +78,31 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       );
 
     case 'buddies/changeBanStatusBatch/end':
-      console.log(action.payload);
+      if (E.isRight(action.payload)) {
+        const items = action.payload.right;
+
+        const deletedIds = Object.keys(items).filter(
+          key => items[key].status === 'Deleted',
+        );
+
+        if (RD.isSuccess(state)) {
+          const filteredIds = Object.keys(state.value).filter(
+            buddyId => !deletedIds.includes(buddyId),
+          );
+
+          const newState = filteredIds.reduce<Record<string, buddyApi.Buddy>>(
+            (acc, curr) => {
+              return { ...acc, [curr]: state.value[curr] };
+            },
+            {},
+          );
+
+          return RD.success(newState);
+        }
+
+        return state;
+      }
+
       return state;
 
     default:

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -60,6 +60,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     case 'buddies/completed':
       return RD.fromEither(action.payload);
 
+<<<<<<< HEAD
 
     case 'buddies/changeBanStatusBatch/start':
       return automaton.loop(
@@ -73,6 +74,8 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
         ),
       );
 
+=======
+>>>>>>> New reducer for banRequest
     case 'buddies/changeBanStatus/end':
       return pipe(
         action.payload,

--- a/src/state/reducers/index.ts
+++ b/src/state/reducers/index.ts
@@ -11,6 +11,7 @@ import * as accessToken from './accessToken';
 import * as login from './login';
 import * as createUser from './createUser';
 import * as buddies from './buddies';
+import * as banBuddyRequest from './banBuddyRequest';
 import * as messages from './messages';
 import * as newMessage from './newMessage';
 import * as mentors from './mentors';
@@ -62,6 +63,7 @@ export const rootReducer: automaton.Reducer<AppState, actions.Action> =
       mentors: mentors.reducer,
       skillFilter: mentors.skillReducer,
       buddies: buddies.reducer,
+      banBuddyRequest: banBuddyRequest.reducer,
       messages: messages.reducer,
       newMessage: newMessage.reducer,
       markMessageSeen: markSeen.reducer,
@@ -83,6 +85,7 @@ export const initialState: AppState = {
   mentors: mentors.initialState,
   skillFilter: [],
   buddies: buddies.initialState,
+  banBuddyRequest: banBuddyRequest.initialState,
   messages: messages.initialState,
   newMessage: {},
   markMessageSeen: {},

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -40,6 +40,7 @@ export type AppState = {
   mentors: RemoteData<Record<BuddyId, mentorsApi.Mentor>>;
   skillFilter: string[];
   buddies: RemoteData<Record<BuddyId, buddyApi.Buddy>>;
+  banBuddyRequest: RemoteAction;
 
   messages: {
     polling: boolean;


### PR DESCRIPTION
After changing buddy ban-status, the state was not set properly. 
These changes should fix the problem. 
Now creating a new slice of state that keeps track of the ban-request.

[Trello-card](https://trello.com/c/UdiRmPKV/466-inconsistent-state-after-banning-restoring-contact)