### PR TITLE
Status message in settings

### DIFF
--- a/e2e/fixtures/accounts.json
+++ b/e2e/fixtures/accounts.json
@@ -59,6 +59,8 @@
             "communication_channels": ["phone", "email"],
             "gender": "other",
             "region": "Tampesteri",
+            "is_vacationing": true,
+            "status_message": "Gone gardening",
             "role": "mentor"
         }
     ]

--- a/e2e/fixtures/accounts.json
+++ b/e2e/fixtures/accounts.json
@@ -19,7 +19,6 @@
         {
             "loginName": "mentor1",
             "displayName": "mentor1_nick",
-            "is_vacationing": true,
             "password": "mentormentor",
             "email": "mentor1@mentor.mentor",
             "birthYear": 1980,

--- a/e2e/statusMessageTest.spec.ts
+++ b/e2e/statusMessageTest.spec.ts
@@ -1,0 +1,50 @@
+import { by, element, expect, device } from 'detox';
+import { describe, it, beforeEach } from '@jest/globals';
+
+import {
+  APISignUpMentor,
+  APIDeleteAccounts,
+  signIn,
+  waitAndTypeText,
+  forceLogout,
+  scrollDownAndTap,
+} from './helpers';
+
+const accountFixtures = require('./fixtures/accounts.json');
+
+describe('Change status message', () => {
+  beforeEach(async () => {
+    await APIDeleteAccounts();
+    await device.reloadReactNative();
+  });
+
+  it('for a mentor successfully', async () => {
+    const mentor = accountFixtures.mentors[2];
+    const newStatusMessage = 'On vacation 1.7.-20.7.';
+    await APISignUpMentor(mentor);
+
+    await signIn(mentor);
+
+    await element(by.id('tabs.settings')).tap();
+
+    await scrollDownAndTap(
+      'main.settings.account.status.title',
+      'main.settings.index.view',
+    );
+    await expect(element(by.text(mentor.status_message))).toBeVisible();
+
+    await element(by.id('main.settings.account.status.input')).clearText();
+    await waitAndTypeText(
+      'main.settings.account.status.input',
+      newStatusMessage + '\n',
+    );
+    await scrollDownAndTap(
+      'main.settings.account.status.save',
+      'main.settings.index.view',
+    );
+
+    await expect(element(by.text(newStatusMessage))).toBeVisible();
+
+    await forceLogout();
+  });
+});

--- a/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
+++ b/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import RN from 'react-native';
+
+import * as localization from '../../../../localization';
+
+import Message from '../../../components/Message';
+import Button from '../../../components/Button';
+import colors from '../../../components/colors';
+import fonts from '../../../components/fonts';
+import { textShadow } from '../../../components/shadow';
+
+type Props = {
+  imageSource: RN.ImageSourcePropType;
+  style?: RN.StyleProp<RN.ViewStyle>;
+  imageStyle?: RN.StyleProp<RN.ImageStyle>;
+  messageId: localization.MessageId;
+  onOkPress: () => void;
+  onRetryPress: () => void;
+};
+
+export default (props: Props) => {
+  return (
+    <RN.View style={[styles.container, props.style]}>
+      <RN.Image
+        style={[styles.image, props.imageStyle]}
+        source={props.imageSource}
+      />
+      <Message id={props.messageId} style={styles.text} />
+      <RN.View style={styles.buttonContainer}>
+        <Button
+          onPress={props.onOkPress}
+          messageStyle={styles.buttonText}
+          messageId="meta.ok"
+          style={styles.saveButton}
+        />
+        <Button
+          onPress={props.onRetryPress}
+          messageStyle={styles.buttonText}
+          messageId="components.remoteData.retry"
+          style={styles.saveButton}
+        />
+      </RN.View>
+    </RN.View>
+  );
+};
+
+const styles = RN.StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 24,
+    padding: 24,
+  },
+  text: {
+    color: colors.darkestBlue,
+    ...fonts.largeBold,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  image: {
+    width: 160,
+    height: 160,
+    tintColor: colors.darkestBlue,
+    marginBottom: 40,
+  },
+  buttonContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignSelf: 'stretch',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    marginVertical: 12,
+  },
+  saveButton: {
+    backgroundColor: colors.blue,
+    minWidth: '40%',
+  },
+  buttonText: {
+    color: colors.white,
+    ...fonts.largeBold,
+    ...textShadow,
+  },
+});

--- a/src/Screens/Main/Settings/UserAccount/MentorForm.tsx
+++ b/src/Screens/Main/Settings/UserAccount/MentorForm.tsx
@@ -35,9 +35,11 @@ export default ({ userId }: Props) => {
 
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
 
-  const isLoading = useSelector(selector.getIsChangeVacationStatusLoading);
+  const isVacationStatusLoading = useSelector(
+    selector.getIsChangeVacationStatusLoading,
+  );
 
-  const requestState = useSelector(selector.getStatusMessage);
+  const statusMessageState = useSelector(selector.getStatusMessageChangeState);
 
   const openProfile = () => {
     RN.Linking.openURL(config.loginUrl);
@@ -69,7 +71,7 @@ export default ({ userId }: Props) => {
   };
 
   React.useEffect(() => {
-    if (RD.isSuccess(requestState)) {
+    if (RD.isSuccess(statusMessageState)) {
       const timeout = setTimeout(
         resetStatusMessage,
         changeStatusMessageState.coolDownDuration,
@@ -77,7 +79,7 @@ export default ({ userId }: Props) => {
 
       return () => clearTimeout(timeout);
     }
-  }, [requestState]);
+  }, [statusMessageState]);
 
   React.useEffect(() => {
     setStatusMessage(mentor?.status_message ?? '');
@@ -99,7 +101,7 @@ export default ({ userId }: Props) => {
         style={styles.fieldName}
         id="main.settings.account.vacation.title"
       />
-      {isLoading ? (
+      {isVacationStatusLoading ? (
         <Spinner />
       ) : (
         <ToggleSwitch
@@ -117,7 +119,7 @@ export default ({ userId }: Props) => {
         testID="main.settings.account.status.title"
       />
       {pipe(
-        requestState,
+        statusMessageState,
         RD.fold(
           () => (
             <StatusMessageForm

--- a/src/Screens/Main/Settings/UserAccount/MentorForm.tsx
+++ b/src/Screens/Main/Settings/UserAccount/MentorForm.tsx
@@ -19,6 +19,7 @@ import colors from '../../../components/colors';
 import fonts from '../../../components/fonts';
 
 import AlertBox from './AlertBox';
+import AlertDialog from './AlertDialog';
 import StatusMessageForm from 'src/Screens/components/StatusMessageForm';
 
 type Props = {
@@ -78,6 +79,10 @@ export default ({ userId }: Props) => {
     }
   }, [requestState]);
 
+  React.useEffect(() => {
+    setStatusMessage(mentor?.status_message ?? '');
+  }, [mentor?.status_message]);
+
   return (
     <>
       <Message
@@ -123,11 +128,12 @@ export default ({ userId }: Props) => {
           ),
           () => <Spinner />,
           () => (
-            <AlertBox
+            <AlertDialog
               imageStyle={styles.failBox}
               imageSource={require('../../../images/alert-circle.svg')}
-              duration={changeStatusMessageState.coolDownDuration}
               messageId="main.settings.account.status.fail"
+              onOkPress={resetStatusMessage}
+              onRetryPress={changeStatusMessage}
             />
           ),
           () => (

--- a/src/Screens/components/InputField.tsx
+++ b/src/Screens/components/InputField.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import RN from 'react-native';
+
+import fonts from './fonts';
+import colors from './colors';
+
+export interface Props extends RN.TextInputProps {
+  inputStyle?: RN.StyleProp<RN.ViewStyle>;
+}
+
+const InputField = ({
+  style,
+  inputStyle,
+  numberOfLines,
+  maxLength,
+  ...textInputProps
+}: Props) => {
+  return (
+    <RN.View style={style}>
+      <RN.View>
+        <RN.TextInput
+          style={[inputStyle, styles.inputText]}
+          maxLength={maxLength}
+          multiline={true}
+          numberOfLines={numberOfLines}
+          editable={true}
+          {...textInputProps}
+        />
+      </RN.View>
+    </RN.View>
+  );
+};
+
+const styles = RN.StyleSheet.create({
+  inputText: {
+    ...fonts.largeBold,
+    color: colors.darkestBlue,
+    backgroundColor: colors.lightestGray,
+    alignSelf: 'stretch',
+    flex: 1,
+    flexGrow: 1,
+    paddingVertical: 8,
+    paddingLeft: 16,
+    paddingRight: 48,
+    borderRadius: 16,
+    textAlignVertical: 'top',
+  },
+});
+
+export default InputField;

--- a/src/Screens/components/InputField.tsx
+++ b/src/Screens/components/InputField.tsx
@@ -11,8 +11,9 @@ export interface Props extends RN.TextInputProps {
 const InputField = ({
   style,
   inputStyle,
-  numberOfLines,
   maxLength,
+  multiline,
+  numberOfLines,
   ...textInputProps
 }: Props) => {
   return (
@@ -21,7 +22,7 @@ const InputField = ({
         <RN.TextInput
           style={[inputStyle, styles.inputText]}
           maxLength={maxLength}
-          multiline={true}
+          multiline={multiline}
           numberOfLines={numberOfLines}
           editable={true}
           {...textInputProps}
@@ -33,7 +34,7 @@ const InputField = ({
 
 const styles = RN.StyleSheet.create({
   inputText: {
-    ...fonts.largeBold,
+    ...fonts.regularBold,
     color: colors.darkestBlue,
     backgroundColor: colors.lightestGray,
     alignSelf: 'stretch',

--- a/src/Screens/components/StatusMessageForm.tsx
+++ b/src/Screens/components/StatusMessageForm.tsx
@@ -20,8 +20,8 @@ export default (props: Props) => {
         style={styles.field}
         value={props.statusMessage}
         onChangeText={props.setStatusMessage}
-        numberOfLines={2}
-        maxLength={50}
+        maxLength={30}
+        multiline={false}
         testID="main.settings.account.status.input"
       />
       <Button

--- a/src/Screens/components/StatusMessageForm.tsx
+++ b/src/Screens/components/StatusMessageForm.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import RN from 'react-native';
+
+import Button from './Button';
+import colors from './colors';
+import fonts from './fonts';
+import InputField from './InputField';
+import { textShadow } from './shadow';
+
+type Props = {
+  statusMessage: string;
+  setStatusMessage: React.Dispatch<React.SetStateAction<string>>;
+  onButtonPress: () => void;
+};
+
+export default (props: Props) => {
+  return (
+    <>
+      <InputField
+        style={styles.field}
+        value={props.statusMessage}
+        onChangeText={props.setStatusMessage}
+        numberOfLines={2}
+        maxLength={50}
+        testID="main.settings.account.status.input"
+      />
+      <Button
+        style={styles.saveButton}
+        messageStyle={styles.buttonText}
+        onPress={props.onButtonPress}
+        messageId="meta.save"
+        testID="main.settings.account.status.save"
+      />
+    </>
+  );
+};
+
+const styles = RN.StyleSheet.create({
+  field: {
+    marginVertical: 8,
+  },
+  saveButton: {
+    marginTop: 32,
+    alignSelf: 'flex-start',
+    minWidth: '70%',
+    backgroundColor: colors.blue,
+  },
+  buttonText: {
+    ...fonts.largeBold,
+    ...textShadow,
+    color: colors.white,
+  },
+});

--- a/src/api/mentors.ts
+++ b/src/api/mentors.ts
@@ -89,9 +89,14 @@ export const compare =
     return compareLang(a, b) || compareIds(userId, a, b);
   };
 
+type VacationStatusParams = {
+  is_vacationing: boolean;
+  status_message: string;
+};
+
 const vacationStatusRequest = (
   mentorId: string,
-  data: any,
+  data: VacationStatusParams,
   token: authApi.AccessToken,
 ) => {
   return http.patch(`${config.baseUrl}/mentors/${mentorId}`, data, {

--- a/src/api/mentors.ts
+++ b/src/api/mentors.ts
@@ -89,13 +89,12 @@ export const compare =
     return compareLang(a, b) || compareIds(userId, a, b);
   };
 
-const vacationRequest = (mentor: Mentor, token: authApi.AccessToken) => {
-  const data = {
-    is_vacationing: !mentor.is_vacationing,
-    status_message: mentor.status_message,
-  };
-
-  return http.patch(`${config.baseUrl}/mentors/${mentor.mentorId}`, data, {
+const vacationStatusRequest = (
+  mentorId: string,
+  data: any,
+  token: authApi.AccessToken,
+) => {
+  return http.patch(`${config.baseUrl}/mentors/${mentorId}`, data, {
     headers: authApi.authHeader(token),
   });
 };
@@ -103,5 +102,27 @@ const vacationRequest = (mentor: Mentor, token: authApi.AccessToken) => {
 export function changeVacationStatus(
   mentor: Mentor,
 ): (token: authApi.AccessToken) => TE.TaskEither<string, Response> {
-  return token => http.response(vacationRequest(mentor, token));
+  const data = {
+    is_vacationing: !mentor.is_vacationing,
+    status_message: mentor.status_message,
+  };
+
+  return token =>
+    http.response(vacationStatusRequest(mentor.mentorId, data, token));
+}
+
+export function changeStatusMessage({
+  statusMessage,
+  mentor,
+}: {
+  statusMessage: string;
+  mentor: Mentor;
+}): (token: authApi.AccessToken) => TE.TaskEither<string, Response> {
+  const data = {
+    is_vacationing: mentor.is_vacationing,
+    status_message: statusMessage,
+  };
+
+  return token =>
+    http.response(vacationStatusRequest(mentor.mentorId, data, token));
 }

--- a/src/localization/en.ts
+++ b/src/localization/en.ts
@@ -83,6 +83,10 @@ export const messages: { [key in MessageId]: string } = {
   'main.settings.account.profile.button': 'Edit Profile',
   'main.settings.account.profile.title': 'Profile',
 
+  'main.settings.account.status.fail': 'Changing status message failed!',
+  'main.settings.account.status.success': 'Changing status message succeeded!',
+  'main.settings.account.status.title': 'Status message',
+
   'main.settings.account.title': 'Account settings',
   'main.settings.account.userName': 'Username',
 

--- a/src/localization/fi.ts
+++ b/src/localization/fi.ts
@@ -81,6 +81,10 @@ export const messages = {
   'main.settings.account.profile.button': 'Muokkaa profiilia',
   'main.settings.account.profile.title': 'Profiili',
 
+  'main.settings.account.status.fail': 'Oman tilan muutos epäonnistui!',
+  'main.settings.account.status.success': 'Oman tilan muutos onnistui!',
+  'main.settings.account.status.title': 'Oma tila',
+
   'main.settings.account.title': 'Asetukset',
   'main.settings.account.userName': 'Käyttäjätunnus',
 

--- a/src/state/actions/regular.ts
+++ b/src/state/actions/regular.ts
@@ -26,6 +26,13 @@ type RegularActions = {
   'mentor/changeVacationStatus/start': { mentor: mentorApi.Mentor };
   'mentor/changeVacationStatus/end': E.Either<string, Response>;
 
+  'mentor/changeStatusMessage/start': {
+    statusMessage: string;
+    mentor: mentorApi.Mentor;
+  };
+  'mentor/changeStatusMessage/completed': E.Either<string, Response>;
+  'mentor/changeStatusMessage/reset': undefined;
+
   'skillFilter/toggled': { skillName: string };
   'skillFilter/reset': undefined;
 

--- a/src/state/reducers/changeStatusMessage.ts
+++ b/src/state/reducers/changeStatusMessage.ts
@@ -1,8 +1,6 @@
 /* global Response */
 import * as automaton from 'redux-automaton';
 import * as RD from '@devexperts/remote-data-ts';
-import * as T from 'fp-ts/lib/Task';
-import { pipe } from 'fp-ts/lib/pipeable';
 
 import * as mentorsApi from '../../api/mentors';
 
@@ -10,7 +8,6 @@ import * as actions from '../actions';
 
 import { AppState } from '../types';
 import { withToken } from './accessToken';
-import { cmd } from '../middleware';
 
 export const initialState = RD.initial;
 export const coolDownDuration = 5000;
@@ -28,23 +25,16 @@ export const reducer: automaton.Reducer<
           actions.make('mentor/changeStatusMessage/completed'),
         ),
       );
-    case 'mentor/changeStatusMessage/completed':
-      return automaton.loop(
-        RD.fromEither(action.payload),
-        cmd(
-          pipe(
-            T.of(undefined),
-            T.map(actions.make('mentor/changeStatusMessage/reset')),
-            T.delay(coolDownDuration),
-          ),
-        ),
-      );
-    case 'mentor/changeStatusMessage/reset':
-      if (RD.isPending(state)) {
-        return state;
-      }
 
-      return RD.initial;
+    case 'mentor/changeStatusMessage/completed':
+      return RD.fromEither(action.payload);
+
+    case 'mentor/changeStatusMessage/reset':
+      return automaton.loop(
+        RD.initial,
+        actions.make('mentors/start')(undefined),
+      );
+
     default:
       return state;
   }

--- a/src/state/reducers/changeStatusMessage.ts
+++ b/src/state/reducers/changeStatusMessage.ts
@@ -1,0 +1,53 @@
+/* global Response */
+import * as automaton from 'redux-automaton';
+import * as RD from '@devexperts/remote-data-ts';
+import * as T from 'fp-ts/lib/Task';
+import { pipe } from 'fp-ts/lib/pipeable';
+
+import * as mentorsApi from '../../api/mentors';
+
+import * as actions from '../actions';
+
+import { AppState } from '../types';
+import { withToken } from './accessToken';
+import { cmd } from '../middleware';
+
+export const initialState = RD.initial;
+export const coolDownDuration = 5000;
+
+export const reducer: automaton.Reducer<
+  RD.RemoteData<string, Response>,
+  actions.Action
+> = (state = initialState, action) => {
+  switch (action.type) {
+    case 'mentor/changeStatusMessage/start':
+      return automaton.loop(
+        RD.pending,
+        withToken(
+          mentorsApi.changeStatusMessage(action.payload),
+          actions.make('mentor/changeStatusMessage/completed'),
+        ),
+      );
+    case 'mentor/changeStatusMessage/completed':
+      return automaton.loop(
+        RD.fromEither(action.payload),
+        cmd(
+          pipe(
+            T.of(undefined),
+            T.map(actions.make('mentor/changeStatusMessage/reset')),
+            T.delay(coolDownDuration),
+          ),
+        ),
+      );
+    case 'mentor/changeStatusMessage/reset':
+      if (RD.isPending(state)) {
+        return state;
+      }
+
+      return RD.initial;
+    default:
+      return state;
+  }
+};
+
+export const select = ({ changeStatusMessage: state }: AppState) => state;

--- a/src/state/reducers/index.ts
+++ b/src/state/reducers/index.ts
@@ -19,6 +19,7 @@ import * as userAccount from './userAccount';
 import * as changePassword from './changePassword';
 import * as changeEmail from './changeEmail';
 import * as changeVacationStatus from './changeVacationStatus';
+import * as changeStatusMessage from './changeStatusMessage';
 import * as notifications from './notifications';
 import * as deleteAccount from './deleteAccount';
 
@@ -55,6 +56,7 @@ export const rootReducer: automaton.Reducer<AppState, actions.Action> =
       changePassword: changePassword.reducer,
       changeEmail: changeEmail.reducer,
       changeVacationStatus: changeVacationStatus.reducer,
+      changeStatusMessage: changeStatusMessage.reducer,
       notifications: notifications.reducer,
       deleteAccount: deleteAccount.reducer,
       mentors: mentors.reducer,
@@ -75,6 +77,7 @@ export const initialState: AppState = {
   changePassword: changePassword.initialState,
   changeEmail: changeEmail.initialState,
   changeVacationStatus: changeVacationStatus.initialState,
+  changeStatusMessage: changeStatusMessage.initialState,
   notifications: notifications.initialState,
   deleteAccount: deleteAccount.initialState,
   mentors: mentors.initialState,

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -112,7 +112,7 @@ export const getIsChangeVacationStatusLoading = (appState: AppState) => {
   return RD.isPending(mentorState) || RD.isPending(changeVacationStatusState);
 };
 
-export const getStatusMessage = (appState: AppState) => {
+export const getStatusMessageChangeState = (appState: AppState) => {
   const mentorState = selectMentors(appState);
   const changeStatusMessageState = selectStatusMessage(appState);
 

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -19,6 +19,7 @@ import { AppState } from './types';
 
 import { select as selectMentors } from './reducers/mentors';
 import { select as selectVacationStatus } from './reducers/changeVacationStatus';
+import { select as selectStatusMessage } from './reducers/changeStatusMessage';
 
 export function getMentors(
   mentors: RD.RemoteData<string, Record<string, mentorsApi.Mentor>>,
@@ -109,4 +110,11 @@ export const getIsChangeVacationStatusLoading = (appState: AppState) => {
   const changeVacationStatusState = selectVacationStatus(appState);
 
   return RD.isPending(mentorState) || RD.isPending(changeVacationStatusState);
+};
+
+export const getStatusMessage = (appState: AppState) => {
+  const mentorState = selectMentors(appState);
+  const changeStatusMessageState = selectStatusMessage(appState);
+
+  return RD.combine(mentorState, changeStatusMessageState);
 };

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -116,5 +116,9 @@ export const getStatusMessage = (appState: AppState) => {
   const mentorState = selectMentors(appState);
   const changeStatusMessageState = selectStatusMessage(appState);
 
-  return RD.combine(mentorState, changeStatusMessageState);
+  if (RD.isPending(mentorState)) {
+    return mentorState;
+  }
+
+  return changeStatusMessageState;
 };

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -32,6 +32,7 @@ export type AppState = {
   changePassword: RemoteAction;
   changeEmail: RemoteData<{ email?: string }>;
   changeVacationStatus: RemoteAction;
+  changeStatusMessage: RemoteAction;
   userAccount: RemoteData<accountApi.UserAccount>;
 
   deleteAccount: RemoteAction;


### PR DESCRIPTION
Add status message field and a save button to mentor's settings page. For now, the save button only saves the status message, but in future it can be used for changing other information as well. The length of the status message is limited to 30 characters.


Status message field (on Android):
<img src="https://user-images.githubusercontent.com/36920208/131487033-1e57c365-13f3-405a-8b0a-656414ab20de.png" width="300">
Status message is changed successfully:
<img src="https://user-images.githubusercontent.com/36920208/131464323-0c93e4b1-16f0-4fc0-8209-0354e3d6d37a.png" width="300">
Changing status message fails for some reason:
<img src="https://user-images.githubusercontent.com/36920208/131671478-cdd51858-006d-4ad3-be47-55e172b6d2f2.png" width="300">
