### PR TITLE
Remove birth_year from e2e helper

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -230,7 +230,6 @@ export async function APISignUpMentor(mentor: any) {
     headers: headers,
     body: JSON.stringify({
       display_name: mentor.displayName,
-      birth_year: mentor.birthYear,
       role: mentor.role,
       account_id: myuser.account.id,
       id: myuser.user.id,


### PR DESCRIPTION
Birth year is not needed for user, only mentor resource.