### PR TITLE
Fix build configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,10 @@ def enableHermes = project.ext.react.get("enableHermes", false);
 def isAppCenterBuild = System.getenv('APPCENTER_BUILD_ID') ? true : false;
 
 android {
+    // 28.9.2021 - Felix
+    // from react-native upgrade-helper
+    ndkVersion rootProject.ext.ndkVersion
+
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     compileOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         targetSdkVersion = 29
         supportLibVersion = "28.0.0"
         kotlinVersion = '1.4.10'
+        ndkVersion = "20.1.5948944"
     }
     repositories {
         google()
@@ -17,13 +18,15 @@ buildscript {
     dependencies {
         // 27.9.2021 - Felix
         // From 3.5.3 to 4.1.0 because of gradle-task-fail on appcenter
-        // Also gradle-wrapper-properties distributionUrl from 6.2 => 6.5
+        // Also gradle-wrapper-properties distributionUrl from 6.2 => 6.7
 
         // AGP version and Required Gradle version
         // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
   
         // Choosing AGP version changes default NDK version
         // https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
+
+        // Also added ndkVersion because it is in the react-native upgrade-helper from 0.63.4 -> 0.64.0
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // for push notifications

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,16 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        // 27.9.2021 - Felix
+        // From 3.5.3 to 4.1.0 because of gradle-task-fail on appcenter
+        // Also gradle-wrapper-properties distributionUrl from 6.2 => 6.5
+
+        // AGP version and Required Gradle version
+        // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+  
+        // Choosing AGP version changes default NDK version
+        // https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
+        classpath("com.android.tools.build:gradle:4.1.0")
 
         // for push notifications
         classpath 'com.google.gms:google-services:4.3.3'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
App Center Android build fails because of wrong Android Gradle Plugin and Android Native Development Kit versions.
Use AGP 4.1 and Gradle version 6.7 and NDK 20.1.5948944 from react-native-upgrade-helper.

These configs builds on App Center!

React native upgrade helper
https://react-native-community.github.io/upgrade-helper/?from=0.63.4&to=0.64.0

AGP version and Required Gradle version
https://developer.android.com/studio/releases/gradle-plugin#updating-gradle

Choosing AGP version changes default NDK version
https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp