### PR TITLE
Fix e2e changeStatusMessage-test

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -8,13 +8,18 @@ const API_PASS = process.env.YLITSE_API_PASS || '';
 /**
  * Scrolls view down if needed and taps the given element
  */
-export async function scrollDownAndTap(elementId: string, viewId: string) {
-  await scrollDownTo(elementId, viewId);
+export async function scrollDownAndTap(
+  elementId: string,
+  viewId: string,
+  xPosition: number = 0.1,
+  yPosition: number = 0.2,
+) {
+  await scrollDownTo(elementId, viewId, xPosition, yPosition);
 
   // App has big sticky toolbar at the bottom
   // Scroll down little bit more to be able to tap the element
   try {
-    await element(by.id(viewId)).scroll(100, 'down', 0.1, 0.2);
+    await element(by.id(viewId)).scroll(100, 'down', xPosition, yPosition);
   } catch (error) {
     // Do nothing, cannot scroll down anymore
   }
@@ -25,13 +30,18 @@ export async function scrollDownAndTap(elementId: string, viewId: string) {
 /**
  * Scrolls view down until element is found
  */
-export async function scrollDownTo(elementId: string, viewId: string) {
+export async function scrollDownTo(
+  elementId: string,
+  viewId: string,
+  xPosition: number = 0.1,
+  yPosition: number = 0.2,
+) {
   await waitFor(element(by.id(elementId)))
     .toBeVisible()
     .whileElement(by.id(viewId))
     // Needs to scroll from x=0.1, y=0.2
     // because of the big sticky toolbar
-    .scroll(200, 'down', 0.1, 0.2);
+    .scroll(200, 'down', xPosition, yPosition);
 }
 
 /**

--- a/e2e/statusMessageTest.spec.ts
+++ b/e2e/statusMessageTest.spec.ts
@@ -100,7 +100,11 @@ describe('Change status message', () => {
     await scrollDownAndTap(
       'main.settings.account.status.save',
       'main.settings.index.view',
+      0.0,
+      0.2,
     );
+
+    await element(by.id('main.settings.account.status.save')).tap();
 
     await expect(element(by.text(newStatusMessage))).toBeVisible();
 


### PR DESCRIPTION
Depending on simulator, when scrolling down the form, it will touch the
Switch and then the test fails, because the Switch causes the app to
patch wrong data. Did not work with iPhone 11 simulator.

Added a option to set coordinates (x, y) on scroll position, and
keeping (0.1, 0.2) as default. This tests needs xPosition at the left-side of screen (0.0)

Tap the save-button again because of multiline input-field needs to be
focused out of. Scrolling is not enough.

Now tests pass also with iPhone11 simulator.