### PR TITLE
Bump lodash, path-parse, tmpl, y18n

### DIFF
--- a/.detoxrc.json
+++ b/.detoxrc.json
@@ -7,7 +7,7 @@
       "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
       "type": "android.attached",
       "device": {
-        "name": "TODO_INSERT_DEVICE_ID_HERE"
+        "adbName": "TODO_INSERT_DEVICE_ID_HERE"
       }
     },
     "android.genymotion.debug": {
@@ -39,7 +39,8 @@
       "build": "xcodebuild -workspace ios/ylitse.xcworkspace -configuration Debug -scheme ylitse -destination 'platform=iOS Simulator,name=iPhone 11,OS=15.0' -derivedDataPath ios/build",
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 11"
+        "type": "iPhone 11",
+        "os": "iOS 15.0"
       }
     },
     "ios.sim.twelve-mini.debug": {
@@ -47,7 +48,8 @@
       "build": "xcodebuild -workspace ios/ylitse.xcworkspace -configuration Debug -scheme ylitse -destination 'platform=iOS Simulator,name=iPhone 12 mini,OS=15.0' -derivedDataPath ios/build",
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 12 mini"
+        "type": "iPhone 12 mini",
+        "os": "iOS 15.0"
       }
     },
     "ios.sim.se.debug": {
@@ -55,7 +57,8 @@
       "build": "xcodebuild -workspace ios/ylitse.xcworkspace -configuration Debug -scheme ylitse -destination 'platform=iOS Simulator,name=iPhone SE (2nd generation),OS=15.0' -derivedDataPath ios/build",
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone SE (2nd generation)"
+        "type": "iPhone SE (2nd generation)",
+        "os": "iOS 15.0"
       }
     }
   }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -627,7 +627,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: db2f6e22a534d466fc0e34e622df47d9d20bab2f
   React-jsinspector: 8c0517dee5e8c70cd6c3066f20213ff7ce54f176
   React-logger: bfddd3418dc1d45b77b822958f3e31422e2c179b
-  react-native-safe-area-context: 86612d2c9a9e94e288319262d10b5f93f0b395f5
+  react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
   React-perflogger: fcac6090a80e3d967791b4c7f1b1a017f9d4a398
   React-RCTActionSheet: caf5913d9f9e605f5467206cf9d1caa6d47d7ad6
   React-RCTAnimation: 6539e3bf594f6a529cd861985ba6548286ae1ead
@@ -640,8 +640,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 6600b5eed7c0fda4a433fa1198d1cb2690151791
   React-runtimeexecutor: 33a949a51bec5f8a3c9e8d8092deb259600d761e
   ReactCommon: 620442811dc6f707b4bf5e3b27d4f19c12d5a821
-  RNCAsyncStorage: bc2f81cc1df90c267ce9ed30bb2dbc93b945a8ee
-  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
+  RNCAsyncStorage: 05bae7ecfab1cbd5441993f1ca098f7c3b3f8d0e
+  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNFBApp: 2b4e07dfca4cf780b9e2d61bcc21e34d890cd654
   RNFBMessaging: f2480f83c9dc254681ee3cdf24495f3e894f55d7
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
@@ -652,4 +652,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: e9290e7efae06f9c18df59edb64307c8a3a16d15
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,9 @@
         "fp-ts-rxjs": "0.6.11",
         "io-ts": "2.2.13",
         "io-ts-promise": "2.0.2",
+        "lodash": "4.17.21",
         "monocle-ts": "2.3.3",
+        "path-parse": "^1.0.7",
         "react": "17.0.2",
         "react-native": "0.66.1",
         "react-native-gesture-handler": "1.9.0",
@@ -31,7 +33,9 @@
         "react-navigation-tabs": "2.10.1",
         "react-redux": "7.2.2",
         "redux": "4.0.5",
-        "redux-automaton": "0.1.3"
+        "redux-automaton": "0.1.3",
+        "tmpl": "1.0.5",
+        "y18n": "4.0.1"
       },
       "devDependencies": {
         "@babel/core": "7.12.9",
@@ -4017,12 +4021,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@jest/core/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
-    },
     "node_modules/@jest/core/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5458,12 +5456,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument/node_modules/source-map": {
       "version": "0.5.7",
@@ -10578,9 +10570,9 @@
       }
     },
     "node_modules/detox/node_modules/y18n": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -14505,12 +14497,6 @@
         }
       }
     },
-    "node_modules/istanbul-lib-instrument/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
     "node_modules/istanbul-lib-instrument/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -15936,12 +15922,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
-    },
-    "node_modules/jest-config/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
     },
     "node_modules/jest-config/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver": {
       "version": "5.7.1",
@@ -19752,12 +19732,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/jest-runtime/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "dev": true
-    },
     "node_modules/jest-runtime/node_modules/istanbul-lib-instrument/node_modules/@babel/core/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -21699,12 +21673,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/jest/node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
     },
     "node_modules/jest/node_modules/yargs": {
       "version": "15.4.1",
@@ -25733,9 +25701,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-starts-with": {
       "version": "1.0.0",
@@ -27179,12 +27147,6 @@
       "peerDependencies": {
         "request": "^2.34"
       }
-    },
-    "node_modules/request-promise-core/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
@@ -28902,9 +28864,9 @@
       }
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -30040,9 +30002,9 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "node_modules/yallist": {
       "version": "2.1.2",
@@ -30161,6 +30123,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/yargs/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     }
   },
   "dependencies": {
@@ -33152,12 +33119,6 @@
                 "source-map": "^0.5.0"
               },
               "dependencies": {
-                "lodash": {
-                  "version": "4.17.20",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                  "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                  "dev": true
-                },
                 "semver": {
                   "version": "5.7.1",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -34326,12 +34287,6 @@
                   "dev": true
                 }
               }
-            },
-            "lodash": {
-              "version": "4.17.21",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-              "dev": true
             },
             "source-map": {
               "version": "0.5.7",
@@ -38279,9 +38234,9 @@
           "requires": {}
         },
         "y18n": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yallist": {
@@ -41271,12 +41226,6 @@
             "ms": "2.1.2"
           }
         },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -41738,12 +41687,6 @@
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0"
           }
-        },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
         },
         "yargs": {
           "version": "15.4.1",
@@ -42801,12 +42744,6 @@
                 "source-map": "^0.5.0"
               },
               "dependencies": {
-                "lodash": {
-                  "version": "4.17.20",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                  "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                  "dev": true
-                },
                 "semver": {
                   "version": "5.7.1",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -45826,12 +45763,6 @@
                 "source-map": "^0.5.0"
               },
               "dependencies": {
-                "lodash": {
-                  "version": "4.17.20",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                  "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                  "dev": true
-                },
                 "semver": {
                   "version": "5.7.1",
                   "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -50105,9 +50036,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-starts-with": {
       "version": "1.0.0",
@@ -51243,14 +51174,6 @@
       "dev": true,
       "requires": {
         "lodash": "^4.17.19"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-          "dev": true
-        }
       }
     },
     "request-promise-native": {
@@ -52568,9 +52491,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -53448,9 +53371,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -53503,6 +53426,11 @@
           "requires": {
             "ansi-regex": "^5.0.1"
           }
+        },
+        "y18n": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "lint": "npx tsc && npm run eslint && npm run prettier",
     "postinstall": "patch-package"
   },
+  "comments": [
+    "lodash, path-parse, tmpl, y18n can be removed from dependencies when you are able to update jest"
+  ],
   "dependencies": {
     "@devexperts/remote-data-ts": "2.0.4",
     "@react-native-async-storage/async-storage": "1.13.2",
@@ -25,7 +28,9 @@
     "fp-ts-rxjs": "0.6.11",
     "io-ts": "2.2.13",
     "io-ts-promise": "2.0.2",
+    "lodash": "4.17.21",
     "monocle-ts": "2.3.3",
+    "path-parse": "^1.0.7",
     "react": "17.0.2",
     "react-native": "0.66.1",
     "react-native-gesture-handler": "1.9.0",
@@ -38,7 +43,9 @@
     "react-navigation-tabs": "2.10.1",
     "react-redux": "7.2.2",
     "redux": "4.0.5",
-    "redux-automaton": "0.1.3"
+    "redux-automaton": "0.1.3",
+    "tmpl": "1.0.5",
+    "y18n": "4.0.1"
   },
   "devDependencies": {
     "@babel/core": "7.12.9",


### PR DESCRIPTION
Bump few packages by listing them in dependencies.

package-lock.json is messed up at the moment. npm audit fix command fails.

```
13:20 $ npm audit fix
npm ERR! Cannot read properties of null (reading 'children')

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ziz/.npm/_logs/2021-12-16T11_21_10_413Z-debug.log
```