### PR TITLE
Fix overflowing switch message in Onboarding

### DIFF
--- a/src/Screens/Onboarding/PrivacyPolicy.tsx
+++ b/src/Screens/Onboarding/PrivacyPolicy.tsx
@@ -95,6 +95,7 @@ const PrivacyPolicy = ({
 
         <MessageSwitch
           style={styles.switch}
+          messageStyle={styles.switchMessage}
           containerStyle={styles.toggleMargin}
           onPress={() => setIsOver15(!isOver15)}
           value={isOver15}
@@ -104,6 +105,7 @@ const PrivacyPolicy = ({
         />
         <MessageSwitch
           style={styles.switch}
+          messageStyle={styles.switchMessage}
           containerStyle={styles.toggleMargin}
           onPress={() => setAgreed(!isAgreed)}
           value={isAgreed}
@@ -201,6 +203,10 @@ const styles = RN.StyleSheet.create({
   link: {},
   errorText: {},
   switch: {},
+  switchMessage: {
+    ...fonts.regular,
+    flexShrink: 1,
+  },
 });
 
 export default ReactRedux.connect<StateProps, {}, OwnProps, state.AppState>(

--- a/src/Screens/Onboarding/PrivacyPolicy.tsx
+++ b/src/Screens/Onboarding/PrivacyPolicy.tsx
@@ -205,7 +205,6 @@ const styles = RN.StyleSheet.create({
   switch: {},
   switchMessage: {
     ...fonts.regular,
-    flexShrink: 1,
   },
 });
 

--- a/src/Screens/components/MessageSwitch.tsx
+++ b/src/Screens/components/MessageSwitch.tsx
@@ -45,6 +45,7 @@ const styles = RN.StyleSheet.create({
     ...fonts.large,
     color: colors.darkestBlue,
     marginLeft: 16,
+    flexShrink: 1,
   },
 });
 


### PR DESCRIPTION
### Message overflowed the card. Now wrap the message inside the flex container. Also decrease fontsize of text

#### 5 inch Android emulator screenshots:

##### Real content
<img src="https://user-images.githubusercontent.com/34128180/148176119-416ed796-d7a0-4d2b-a846-8d0fe5d2388e.png" width=50% height=50%>

##### Overflowing content
<img src="https://user-images.githubusercontent.com/34128180/148176127-eb9d2d98-16ab-4edc-9c4a-1e2ad4d65be2.png" width=50% height=50%>

#### 4.7 inch iPhone SE simulator screenshots

##### Real content
<img src="https://user-images.githubusercontent.com/34128180/148176106-febc5930-0126-4c21-bc2d-b165673dc4e3.png" width=50% height=50%>

##### Overflowing content
<img src="https://user-images.githubusercontent.com/34128180/148176109-5cf94558-ae90-4a99-b61e-fa758a118d37.png" width=50% height=50%>

