### PR TITLE
Add air between AlertDialog buttons

### DIFF
--- a/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
+++ b/src/Screens/Main/Settings/UserAccount/AlertDialog.tsx
@@ -31,13 +31,13 @@ export default (props: Props) => {
           onPress={props.onOkPress}
           messageStyle={styles.buttonText}
           messageId="meta.ok"
-          style={styles.saveButton}
+          style={[styles.button, styles.leftButton]}
         />
         <Button
           onPress={props.onRetryPress}
           messageStyle={styles.buttonText}
           messageId="components.remoteData.retry"
-          style={styles.saveButton}
+          style={styles.button}
         />
       </RN.View>
     </RN.View>
@@ -66,14 +66,11 @@ const styles = RN.StyleSheet.create({
   },
   buttonContainer: {
     flexDirection: 'row',
-    alignSelf: 'stretch',
-    justifyContent: 'space-between',
-    paddingHorizontal: 12,
     marginVertical: 12,
   },
-  saveButton: {
+  leftButton: { marginRight: 24 },
+  button: {
     backgroundColor: colors.blue,
-    minWidth: '40%',
   },
   buttonText: {
     color: colors.white,


### PR DESCRIPTION
### Add minimum margin of 24 between buttons

### iPhone SE simulator
<img src="https://user-images.githubusercontent.com/34128180/148637933-9dad010b-16a6-44aa-9f33-ba948f6f9eb7.png" width=50% height=50%>
<img src="https://user-images.githubusercontent.com/34128180/148637932-b601034e-4149-4a37-adc3-a25ee59ae22e.png" width=50% height=50%>

#### with overflowing text.. looks a bit silly, but does not break
<img src="https://user-images.githubusercontent.com/34128180/148637936-d87a16e0-0134-419f-a8ad-3f5299b72a68.png" width=50% height=50%>


### iPhone 11 simulator
<img src="https://user-images.githubusercontent.com/34128180/148637939-3bbc1357-52a6-42ea-96db-bf4baffe517d.png" width=50% height=50%>

<img src="https://user-images.githubusercontent.com/34128180/148637940-1fafa508-575b-4432-bcaa-04789d44503c.png" width=50% height=50%>

#### with overflowing text.. looks a bit silly, but does not break
<img src="https://user-images.githubusercontent.com/34128180/148637937-f0323f03-4a28-428d-83fb-1410e60a59a2.png" width=50% height=50%>


### Pixel 3a 5.6 inch emulator
<img src="https://user-images.githubusercontent.com/34128180/148638380-f77ec635-a210-4abe-a05c-93cb1f23f4f7.png" width=50% height=50%>

<img src="https://user-images.githubusercontent.com/34128180/148638381-9336fe14-8e44-448c-92e4-7dd7663d6854.png" width=50% height=50%>

#### with overflowing text.. looks a bit silly, but does not break
<img src="https://user-images.githubusercontent.com/34128180/148638378-657572ed-0bdf-496e-a671-4d3c20119eda.png" width=50% height=50%>