### PR TITLE
Skills and mentor stats

### DIFF
--- a/src/Screens/Main/MentorList.tsx
+++ b/src/Screens/Main/MentorList.tsx
@@ -4,6 +4,10 @@ import { SafeAreaView } from 'react-navigation';
 
 import * as navigationProps from '../../lib/navigation-props';
 
+import * as redux from 'redux';
+import { useDispatch } from 'react-redux';
+import * as actions from '../../state/actions';
+
 import * as mentorApi from '../../api/mentors';
 
 import Background from '../components/Background';
@@ -27,10 +31,20 @@ type OwnProps = navigationProps.NavigationProps<
 type Props = OwnProps;
 
 const MentorList = (props: Props) => {
+  const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
+
   const onPressMentor = (mentor: mentorApi.Mentor) => {
     props.navigation.navigate('Main/MentorCardExpanded', {
       mentor,
       didNavigateFromChat: false,
+    });
+
+    dispatch({
+      type: 'statRequest/start',
+      payload: {
+        name: 'open_mentor_profile',
+        props: { mentor_id: mentor.mentorId },
+      },
     });
   };
 

--- a/src/Screens/Main/SearchMentor.tsx
+++ b/src/Screens/Main/SearchMentor.tsx
@@ -44,6 +44,12 @@ export default ({ navigation }: Props) => {
   );
 
   const onPressBack = () => {
+    if (selectedSkills.length > 0) {
+      dispatch({
+        type: 'statRequest/start',
+        payload: { name: 'filter_skills', props: { skills: selectedSkills } },
+      });
+    }
     navigation.goBack();
   };
 

--- a/src/Screens/Main/SearchMentor.tsx
+++ b/src/Screens/Main/SearchMentor.tsx
@@ -50,6 +50,7 @@ export default ({ navigation }: Props) => {
         payload: { name: 'filter_skills', props: { skills: selectedSkills } },
       });
     }
+
     navigation.goBack();
   };
 

--- a/src/api/stat.ts
+++ b/src/api/stat.ts
@@ -26,13 +26,9 @@ const stat = t.union([filterSkillStat, openMentorStat]);
 export type Stat = t.TypeOf<typeof stat>;
 
 export const sendStat = (stat: Stat) => (token: authApi.AccessToken) => {
-  const url = `${config.baseUrl}/events/`;
+  const url = `${config.baseUrl}/events`;
 
-  return http.validateResponse(
-    http.post(url, stat, {
-      headers: authApi.authHeader(token),
-    }),
-    t.unknown,
-    _ => true,
-  );
+  return http.post(url, [stat], {
+    headers: authApi.authHeader(token),
+  });
 };

--- a/src/api/stat.ts
+++ b/src/api/stat.ts
@@ -1,0 +1,38 @@
+import * as t from 'io-ts';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as T from 'fp-ts/lib/Task';
+import * as E from 'fp-ts/lib/Either';
+import * as O from 'fp-ts/lib/Option';
+import { pipe } from 'fp-ts/lib/pipeable';
+
+import * as http from '../lib/http';
+import * as validators from '../lib/validators';
+
+import * as authApi from './auth';
+import * as config from './config';
+
+const filterSkillStat = t.interface({
+  name: t.literal('filter_skills'),
+  props: t.strict({ skills: t.array(t.string) }),
+});
+
+const openMentorStat = t.interface({
+  name: t.literal('open_mentor_profile'),
+  props: t.strict({ mentor_id: t.string }),
+});
+
+const stat = t.union([filterSkillStat, openMentorStat]);
+
+export type Stat = t.TypeOf<typeof stat>;
+
+export const sendStat = (stat: Stat) => (token: authApi.AccessToken) => {
+  const url = `${config.baseUrl}/events/`;
+
+  return http.validateResponse(
+    http.post(url, stat, {
+      headers: authApi.authHeader(token),
+    }),
+    t.unknown,
+    _ => true,
+  );
+};

--- a/src/api/stat.ts
+++ b/src/api/stat.ts
@@ -1,29 +1,19 @@
-import * as t from 'io-ts';
-import * as TE from 'fp-ts/lib/TaskEither';
-import * as T from 'fp-ts/lib/Task';
-import * as E from 'fp-ts/lib/Either';
-import * as O from 'fp-ts/lib/Option';
-import { pipe } from 'fp-ts/lib/pipeable';
-
 import * as http from '../lib/http';
-import * as validators from '../lib/validators';
 
 import * as authApi from './auth';
 import * as config from './config';
 
-const filterSkillStat = t.interface({
-  name: t.literal('filter_skills'),
-  props: t.strict({ skills: t.array(t.string) }),
-});
+type FilterSkillStat = {
+  name: 'filter_skills';
+  props: Record<'skills', Array<string>>;
+};
 
-const openMentorStat = t.interface({
-  name: t.literal('open_mentor_profile'),
-  props: t.strict({ mentor_id: t.string }),
-});
+type OpenMentorStat = {
+  name: 'open_mentor_profile';
+  props: Record<'mentor_id', string>;
+};
 
-const stat = t.union([filterSkillStat, openMentorStat]);
-
-export type Stat = t.TypeOf<typeof stat>;
+export type Stat = FilterSkillStat | OpenMentorStat;
 
 export const sendStat = (stat: Stat) => (token: authApi.AccessToken) => {
   const url = `${config.baseUrl}/events`;

--- a/src/state/actions/regular.ts
+++ b/src/state/actions/regular.ts
@@ -8,6 +8,7 @@ import * as mentorApi from '../../api/mentors';
 import * as authApi from '../../api/auth';
 import * as buddyApi from '../../api/buddies';
 import * as messageApi from '../../api/messages';
+import * as statApi from '../../api/stat';
 import { PollingParams } from '../reducers/messages';
 
 type RegularActions = {
@@ -36,6 +37,9 @@ type RegularActions = {
 
   'skillFilter/toggled': { skillName: string };
   'skillFilter/reset': undefined;
+
+  'statRequest/start': statApi.Stat;
+  'statRequest/end': Result<ReturnType<typeof statApi.sendStat>>;
 
   'login/start': authApi.Credentials;
   'login/end': Result<typeof authApi.login>;

--- a/src/state/reducers/index.ts
+++ b/src/state/reducers/index.ts
@@ -23,6 +23,7 @@ import * as changeVacationStatus from './changeVacationStatus';
 import * as changeStatusMessage from './changeStatusMessage';
 import * as notifications from './notifications';
 import * as deleteAccount from './deleteAccount';
+import * as statRequest from './statRequest';
 
 import * as actions from '../actions';
 
@@ -62,6 +63,7 @@ export const rootReducer: automaton.Reducer<AppState, actions.Action> =
       deleteAccount: deleteAccount.reducer,
       mentors: mentors.reducer,
       skillFilter: mentors.skillReducer,
+      statRequest: statRequest.reducer,
       buddies: buddies.reducer,
       banBuddyRequest: banBuddyRequest.reducer,
       messages: messages.reducer,
@@ -84,6 +86,7 @@ export const initialState: AppState = {
   deleteAccount: deleteAccount.initialState,
   mentors: mentors.initialState,
   skillFilter: [],
+  statRequest: statRequest.initialState,
   buddies: buddies.initialState,
   banBuddyRequest: banBuddyRequest.initialState,
   messages: messages.initialState,

--- a/src/state/reducers/statRequest.ts
+++ b/src/state/reducers/statRequest.ts
@@ -26,7 +26,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
     }
 
     case 'statRequest/end': {
-      console.log('sent stat complete', action.payload);
       return state;
     }
     default: {

--- a/src/state/reducers/statRequest.ts
+++ b/src/state/reducers/statRequest.ts
@@ -1,0 +1,23 @@
+import * as automaton from 'redux-automaton';
+import * as RD from '@devexperts/remote-data-ts';
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as E from 'fp-ts/lib/Either';
+
+import * as actions from '../actions';
+import { AppState } from '../types';
+import { withToken } from './accessToken';
+
+export const initialState = RD.initial;
+
+type State = AppState['statRequest'];
+
+export const reducer: automaton.Reducer<State, actions.Action> = (
+  state: State = initialState,
+  action: actions.Action,
+) => {
+  switch (action.type) {
+    default: {
+      return state;
+    }
+  }
+};

--- a/src/state/reducers/statRequest.ts
+++ b/src/state/reducers/statRequest.ts
@@ -1,11 +1,10 @@
 import * as automaton from 'redux-automaton';
 import * as RD from '@devexperts/remote-data-ts';
-import { pipe } from 'fp-ts/lib/pipeable';
-import * as E from 'fp-ts/lib/Either';
 
 import * as actions from '../actions';
 import { AppState } from '../types';
 import { withToken } from './accessToken';
+import * as statApi from '../../api/stat';
 
 export const initialState = RD.initial;
 
@@ -16,6 +15,20 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
   action: actions.Action,
 ) => {
   switch (action.type) {
+    case 'statRequest/start': {
+      return automaton.loop(
+        state,
+        withToken(
+          statApi.sendStat(action.payload),
+          actions.make('statRequest/end'),
+        ),
+      );
+    }
+
+    case 'statRequest/end': {
+      console.log('sent stat complete', action.payload);
+      return state;
+    }
     default: {
       return state;
     }

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -40,6 +40,7 @@ export type AppState = {
 
   mentors: RemoteData<Record<BuddyId, mentorsApi.Mentor>>;
   skillFilter: string[];
+  statRequest: RemoteAction;
   buddies: {
     buddies: RemoteData<Record<BuddyId, buddyApi.Buddy>>;
     isInitialFetch: boolean;


### PR DESCRIPTION
New backend should be able to give out new statistics, mobile implementation for following

1. Skill stats
    When selecting skills for filtering mentors, send request to the API. Data is used to see most interesting skills.

2. Mentor stats
   When opening mentor-profile in the app send a request to the API. Data is used to see most interesting mentors