### PR TITLE
fix mentor chat-screen navigation bug

### DIFF
--- a/src/Screens/Main/MentorCardExpanded.tsx
+++ b/src/Screens/Main/MentorCardExpanded.tsx
@@ -5,6 +5,8 @@ import { SafeAreaView } from 'react-navigation';
 import * as navigationProps from '../../lib/navigation-props';
 
 import * as mentorApi from '../../api/mentors';
+import * as buddyState from '../../state/reducers/buddies';
+import { useSelector } from 'react-redux';
 
 import MentorTitle from '../components/MentorTitle';
 import MentorStory from '../components/MentorStory';
@@ -43,6 +45,8 @@ const MentorCardExpanded = ({ navigation }: Props) => {
   const mentor = navigation.getParam('mentor');
   const didNavigateFromChat = navigation.getParam('didNavigateFromChat');
   const color = getBuddyColor(mentor.buddyId);
+  const isBuddy = useSelector(buddyState.getIsBuddy(mentor.buddyId));
+  const shouldNavigateBack = didNavigateFromChat && isBuddy;
 
   const goBack = () => {
     navigation.goBack();
@@ -95,7 +99,7 @@ const MentorCardExpanded = ({ navigation }: Props) => {
         <SafeAreaView style={styles.safeArea} forceInset={{ bottom: 'always' }}>
           <Button
             style={styles.button}
-            onPress={didNavigateFromChat ? goBack : navigateToChat}
+            onPress={shouldNavigateBack ? goBack : navigateToChat}
             messageId="main.mentorCardExpanded.button"
             disabled={isChatDisabled}
           />

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -176,3 +176,15 @@ const getBuddies =
 export const getBannedBuddies = getBuddies('Banned');
 
 export const getActiveBuddies = getBuddies('NotBanned');
+
+export const getIsBuddy = (buddyId: string) => (appState: types.AppState) => {
+  const { buddies } = appState.buddies;
+
+  if (RD.isSuccess(buddies)) {
+    const foundBuddy = buddies.value[buddyId];
+
+    return !!foundBuddy;
+  }
+
+  return false;
+};


### PR DESCRIPTION
Fix navigation bug which occurs if navigating from Chat-screen to Mentor-Card when mentor is not users buddy (no conversation)

e2e tests pass

https://user-images.githubusercontent.com/34128180/156354553-22091472-ba9e-4423-817f-e3b07884aa3e.mov


