### PR TITLE
Change translation of failed password-message

### DIFF
--- a/src/localization/en.ts
+++ b/src/localization/en.ts
@@ -76,7 +76,8 @@ export const messages: { [key in MessageId]: string } = {
 
   'main.settings.account.password.button': 'Change password',
   'main.settings.account.password.current': 'Current password',
-  'main.settings.account.password.failure': 'Password change failed',
+  'main.settings.account.password.failure':
+    'Password change failed: check your password!',
   'main.settings.account.password.new': 'New Password',
   'main.settings.account.password.repeat': 'Repeat new password',
   'main.settings.account.password.success': 'Password change succeeded',

--- a/src/localization/fi.ts
+++ b/src/localization/fi.ts
@@ -75,7 +75,8 @@ export const messages = {
 
   'main.settings.account.password.button': 'Vaihda salasana',
   'main.settings.account.password.current': 'nykyinen salasana',
-  'main.settings.account.password.failure': 'Salasanan vaihto epäonnistui!',
+  'main.settings.account.password.failure':
+    'Salasanan vaihto epäonnistui: tarkista salasana!',
   'main.settings.account.password.new': 'uusi salasana',
   'main.settings.account.password.repeat': 'toista uusi salasana',
   'main.settings.account.password.success': 'Salasanan vaihto onnistui!',


### PR DESCRIPTION
Changed the translation for failed password-change error

Example:
![Simulator Screen Shot - iPhone 11 - 2022-05-08 at 12 47 11](https://user-images.githubusercontent.com/34128180/167290880-b795925d-63d9-4188-811d-f5bd7df2c936.png)
