### PR TITLE
Read draft-message when opening chat

### DIFF
--- a/src/Screens/Main/Chat/index.tsx
+++ b/src/Screens/Main/Chat/index.tsx
@@ -90,6 +90,10 @@ const Chat = ({ navigation }: Props) => {
 
   const dispatch = ReactRedux.useDispatch<redux.Dispatch<actions.Action>>();
 
+  const getDraftMessage = () => {
+    dispatch({ type: 'newMessage/store/read/start', payload: { buddyId } });
+  };
+
   const setBanStatus = (banStatus: BanAction) => {
     dispatch({
       type: 'buddies/changeBanStatus/start',
@@ -167,6 +171,10 @@ const Chat = ({ navigation }: Props) => {
       return () => clearTimeout(resetAlertTimeOut);
     }
   }, [isMessageSendFailed]);
+
+  React.useEffect(() => {
+    getDraftMessage();
+  }, []);
 
   return (
     <RN.TouchableOpacity

--- a/src/state/reducers/newMessage.ts
+++ b/src/state/reducers/newMessage.ts
@@ -2,7 +2,6 @@ import { loop } from 'redux-automaton';
 import * as RD from '@devexperts/remote-data-ts';
 import * as T from 'fp-ts/lib/Task';
 import * as record from 'fp-ts/lib/Record';
-import * as array from 'fp-ts/lib/Array';
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { flow } from 'fp-ts/lib/function';
@@ -66,17 +65,6 @@ const getPrev = (buddyId: string, state: State) =>
 
 export const reducer = (state: State, action: actions.Action) => {
   switch (action.type) {
-    case 'buddies/completed': {
-      const actionList = pipe(
-        O.fromEither(action.payload),
-        O.map(record.keys),
-        O.getOrElse<string[]>(() => []),
-        array.map(buddyId => ({ buddyId })),
-        array.map(actions.make('newMessage/store/read/start')),
-      );
-
-      return loop(state, ...actionList);
-    }
     case 'newMessage/store/read/start': {
       const { buddyId } = action.payload;
 


### PR DESCRIPTION
Will prevent performance bottleneck and crashing if user has lots of conversations

App had a problem that when user loaded all messages, it tried to set the draft-message state for every-message at once. This caused unresponsive behaviour and even crashing if too many conversations

- will look at draft-message when opening the chat