### PR TITLE
chore: Add PR template for Github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### What has changed?
+Describe code changes for reviewers. Explain the technical solution you have provided and how it solves the related issue. It is nice to have some screenshots, if the change is visual. Preferably multiple devices and the design if it exists.
+
+
+### Why was the change made?
+What is the motivation for this change?
+
+
+### Caveats?
+Does this introduce new warnings or are linter rules suppressed? Why? Is only manual testing applicable for this feature? Is there something special that the reviewer should take into account?
+
+
+### Related Trello issue
+Link to the Trello ticket
+
+### Checklist
+- [ ] I have updated relevant documentation in READMES


### PR DESCRIPTION
# What has changed
- Adds PR template for GH

# Why
- Probably improves documentation quality