### PR TITLE
add Slider-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@devexperts/remote-data-ts": "2.0.4",
         "@react-native-async-storage/async-storage": "1.13.2",
         "@react-native-community/masked-view": "0.1.10",
+        "@react-native-community/slider": "^4.2.1",
         "@react-native-firebase/app": "10.1.0",
         "@react-native-firebase/messaging": "10.1.1",
         "fp-ts": "2.9.1",
@@ -7289,6 +7290,15 @@
       "peerDependencies": {
         "react": "^16.0",
         "react-native": ">=0.57"
+      }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.2.1.tgz",
+      "integrity": "sha512-6HUS5HbB9bvEN4GiwBlxECgPWQIugHE+kfnxqX2jHUl1SE57MRpw00m1qVs4hXtEPQndBl6mAQiGbKCOtLPVbg==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-firebase/app": {
@@ -35701,6 +35711,12 @@
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.10.tgz",
       "integrity": "sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==",
+      "requires": {}
+    },
+    "@react-native-community/slider": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.2.1.tgz",
+      "integrity": "sha512-6HUS5HbB9bvEN4GiwBlxECgPWQIugHE+kfnxqX2jHUl1SE57MRpw00m1qVs4hXtEPQndBl6mAQiGbKCOtLPVbg==",
       "requires": {}
     },
     "@react-native-firebase/app": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@devexperts/remote-data-ts": "2.0.4",
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/masked-view": "0.1.10",
+    "@react-native-community/slider": "^4.2.1",
     "@react-native-firebase/app": "10.1.0",
     "@react-native-firebase/messaging": "10.1.1",
     "fp-ts": "2.9.1",

--- a/src/Screens/components/Slider.tsx
+++ b/src/Screens/components/Slider.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import * as RN from 'react-native';
+
+import RNCSlider from '@react-native-community/slider';
+
+type Props = {
+  onValueChange: (value: number) => void;
+  value: number;
+  valueRange: [number, number];
+};
+
+const Slider: React.FC<Props> = ({
+  onValueChange,
+  value,
+  valueRange: [min, max],
+}) => {
+  return (
+    <RN.View style={styles.sliderContainer}>
+      <RN.Image
+        style={styles.track}
+        source={require('../images/SliderTrack.svg')}
+      />
+      <RNCSlider
+        style={styles.slider}
+        value={value}
+        minimumValue={min}
+        maximumValue={max}
+        minimumTrackTintColor="transparent"
+        maximumTrackTintColor="transparent"
+        thumbImage={require('../images/SliderThumb.svg')}
+        onSlidingComplete={onValueChange}
+      />
+    </RN.View>
+  );
+};
+
+const styles = RN.StyleSheet.create({
+  sliderContainer: {
+    alignContent: 'center',
+    justifyContent: 'center',
+  },
+  slider: {
+    zIndex: 2,
+    alignSelf: 'stretch',
+  },
+  track: {
+    zIndex: 1,
+    position: 'absolute',
+    width: '100%',
+    resizeMode: 'contain',
+  },
+});
+export default Slider;

--- a/src/Screens/images/SliderThumb.svg
+++ b/src/Screens/images/SliderThumb.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="18.5" fill="#009CCC" stroke="#003363" stroke-width="2"/>
+</svg>

--- a/src/Screens/images/SliderTrack.svg
+++ b/src/Screens/images/SliderTrack.svg
@@ -1,0 +1,10 @@
+<svg width="332" height="26" viewBox="0 0 332 26" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1" width="330" height="24" rx="12" fill="url(#paint0_linear_2596_20377)" stroke="#003363" stroke-width="2"/>
+<defs>
+<linearGradient id="paint0_linear_2596_20377" x1="253.066" y1="13" x2="79.4121" y2="13" gradientUnits="userSpaceOnUse">
+<stop stop-color="#98C679"/>
+<stop offset="0.479167" stop-color="#F6AF6E"/>
+<stop offset="1" stop-color="#EB727C"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
### What has changed?
Added Slider-component that is to be used in the Feedback-feature for answering slider-type-questions.

https://user-images.githubusercontent.com/34128180/163576066-8c7162ac-d734-4eee-b443-18ae6a27330c.mov


### Why was the change made?
What is the motivation for this change?


### Caveats?
Added dependency for [react-native-community-slider](https://github.com/callstack/react-native-slider)
Not reasonable to implement the slider, and this library still maintained and seems low risk


### Related Trello issue
[Trello-ticket](https://trello.com/c/2B0emRFW/604-add-feedback-function), [Design](https://www.figma.com/file/2s4zXMYxlwoqfLdBy3fKPj/Version-2.0?node-id=109%3A1059)

### Checklist
- [x] I have updated relevant documentation in READMES
