### PR TITLE
e2e message-send helper

### DIFF
--- a/e2e/archiveTest.spec.ts
+++ b/e2e/archiveTest.spec.ts
@@ -5,8 +5,9 @@ import {
   APISignUpMentee,
   APISignUpMentor,
   APIDeleteAccounts,
+  APIGetSendInfo,
+  APISendMessage,
   signIn,
-  waitAndTypeText,
   forceLogout,
   APIBan,
 } from './helpers';
@@ -27,15 +28,18 @@ describe('Archiving', () => {
     await APISignUpMentee(mentee);
 
     // mentee sends a msg to mentor
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     // mentor side
     await signIn(mentor);
@@ -63,12 +67,12 @@ describe('Archiving', () => {
     await forceLogout();
 
     // mentee sends another msg to mentor
-    await signIn(mentee);
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-    await waitAndTypeText('main.chat.input.input', 'Notice me Senpai!', true);
-    await element(by.id('main.chat.input.button')).tap();
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Notice me Senpai!',
+      headers: menteeHeaders,
+    });
 
     // mentor should see new message indicator
     await signIn(mentor);
@@ -98,15 +102,18 @@ describe('Archiving', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     await APIBan(mentor, mentee, 'archived');
 
@@ -140,16 +147,18 @@ describe('Archiving', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
-
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
     await APIBan(mentor, mentee, 'archived');
 
     await signIn(mentor);
@@ -180,12 +189,12 @@ describe('Archiving', () => {
     await forceLogout();
 
     // mentee can send another msg to mentor
-    await signIn(mentee);
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-    await waitAndTypeText('main.chat.input.input', 'Notice me Senpai!', true);
-    await element(by.id('main.chat.input.button')).tap();
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Notice me Senpai!',
+      headers: menteeHeaders,
+    });
 
     // mentor should not see new message indicator
     await signIn(mentor);

--- a/e2e/banTest.spec.ts
+++ b/e2e/banTest.spec.ts
@@ -5,8 +5,9 @@ import {
   APISignUpMentee,
   APISignUpMentor,
   APIDeleteAccounts,
+  APISendMessage,
+  APIGetSendInfo,
   signIn,
-  waitAndTypeText,
   forceLogout,
   APIBan,
 } from './helpers';
@@ -27,15 +28,18 @@ describe('Banning', () => {
     await APISignUpMentee(mentee);
 
     // mentee sends a msg to mentor
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     // mentor side
     await signIn(mentor);
@@ -63,12 +67,12 @@ describe('Banning', () => {
     await forceLogout();
 
     // mentee sends another msg to mentor
-    await signIn(mentee);
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-    await waitAndTypeText('main.chat.input.input', 'Notice me Senpai!', true);
-    await element(by.id('main.chat.input.button')).tap();
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Notice me Senpai!',
+      headers: menteeHeaders,
+    });
 
     // mentor should not see new message indicator
     await signIn(mentor);
@@ -94,15 +98,18 @@ describe('Banning', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     await APIBan(mentor, mentee);
 
@@ -136,15 +143,18 @@ describe('Banning', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     await APIBan(mentor, mentee);
 
@@ -176,12 +186,12 @@ describe('Banning', () => {
     await forceLogout();
 
     // mentee can send another msg to mentor
-    await signIn(mentee);
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-    await waitAndTypeText('main.chat.input.input', 'Notice me Senpai!', true);
-    await element(by.id('main.chat.input.button')).tap();
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Notice me Senpai!',
+      headers: menteeHeaders,
+    });
 
     // mentor should not see new message indicator
     await signIn(mentor);
@@ -204,31 +214,37 @@ describe('Banning', () => {
     await APISignUpMentor(mentor);
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
-    const mentee1 = accountFixtures.mentees[1];
-    await APISignUpMentee(mentee1);
+    const mentee2 = accountFixtures.mentees[1];
+    await APISignUpMentee(mentee2);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Notice me Senpai!',
+      headers: menteeHeaders,
+    });
 
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
+    const {
+      sender_id: mentee2Id,
+      recipient_id: mentor2Id,
+      headers: mentee2Headers,
+    } = await APIGetSendInfo(mentee2, mentor);
 
-    await forceLogout();
-
-    await signIn(mentee1);
-
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi!', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: mentee2Id,
+      recipient_id: mentor2Id,
+      content: 'Notice me Senpai!',
+      headers: mentee2Headers,
+    });
 
     await APIBan(mentor, mentee);
-    await APIBan(mentor, mentee1);
+    await APIBan(mentor, mentee2);
 
     await signIn(mentor);
 
@@ -244,7 +260,7 @@ describe('Banning', () => {
 
     // mentor should not see mentees' names in banned list
     await expect(element(by.text(mentee.displayName))).toBeNotVisible();
-    await expect(element(by.text(mentee1.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee2.displayName))).toBeNotVisible();
 
     await waitFor(element(by.id('main.folderedlist.back.button')))
       .toBeVisible()
@@ -253,7 +269,7 @@ describe('Banning', () => {
 
     // mentor should not see mentees' names in chats list
     await expect(element(by.text(mentee.displayName))).toBeNotVisible();
-    await expect(element(by.text(mentee1.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee2.displayName))).toBeNotVisible();
 
     await forceLogout();
   });

--- a/e2e/chatListNavigationTest.spec.ts
+++ b/e2e/chatListNavigationTest.spec.ts
@@ -6,7 +6,8 @@ import {
   APISignUpMentor,
   APIDeleteAccounts,
   signIn,
-  waitAndTypeText,
+  APIGetSendInfo,
+  APISendMessage,
   forceLogout,
   APIBan,
 } from './helpers';
@@ -28,15 +29,18 @@ describe('Navigate in chat views', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
 
     await signIn(mentor);
 
@@ -53,16 +57,18 @@ describe('Navigate in chat views', () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
 
-    await signIn(mentee);
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
 
-    await element(by.text('Read more')).tap();
-    await element(by.text('Chat')).tap();
-
-    await waitAndTypeText('main.chat.input.input', 'Hi', true);
-    await element(by.id('main.chat.input.button')).tap();
-
-    await forceLogout();
-
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
     await APIBan(mentor, mentee);
 
     await signIn(mentor);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -324,3 +324,48 @@ export async function APIBan(sender: any, reciever: any, status = 'banned') {
     },
   );
 }
+
+export async function APIGetSendInfo(sender: any, reciever: any) {
+  const admin_access_token = await APIAdminAccessToken();
+  const info = await APIUsers(admin_access_token);
+
+  let sender_info = info.find(
+    (o: any) => o.display_name === sender.displayName,
+  );
+
+  let reciever_info = info.find(
+    (o: any) => o.display_name === reciever.displayName,
+  );
+
+  const access_token = await APIAccessToken(sender.loginName, sender.password);
+
+  const headers = {
+    Authorization: `Bearer ${access_token}`,
+  };
+
+  return { sender_id: sender_info.id, recipient_id: reciever_info.id, headers };
+}
+
+type Data = {
+  sender_id: string;
+  recipient_id: string;
+  content: string;
+  headers: Record<string, string>;
+};
+export async function APISendMessage({
+  sender_id,
+  recipient_id,
+  content,
+  headers,
+}: Data) {
+  await fetch(`${API_URL}/users/${sender_id}/messages`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      sender_id,
+      recipient_id,
+      content,
+      opened: false,
+    }),
+  });
+}


### PR DESCRIPTION
### What has changed?
Created helpers to send messages for the e2e tests, so it would not be required for the test runner to manually log in to the application and push buttons to send messages


### Why was the change made?
Reduce the time of the tests - for example the banTest was reduced from 485 sec to 265 sec


### Caveats?
Improvement only


### Related Trello issue
[Trello card](https://trello.com/c/SIuuciru/608-create-e2e-helpers-for-sending-messages-to-improve-e2e-tests-speed)

### Checklist
- [x] I have updated relevant documentation in READMES
