### PR TITLE
fetch when focusing on main tabs or bringing to foreground

### DIFF
--- a/e2e/feedback.spec.ts
+++ b/e2e/feedback.spec.ts
@@ -174,4 +174,49 @@ describe('Feedback', () => {
     await expect(firstText).not.toBeVisible();
     await expect(secondText).not.toBeVisible();
   });
+
+  it('fetches and shows questions when focusing on tab screen', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+
+    const firstQuestion = questions[0];
+
+    // mentee sign in
+    await signIn(mentee);
+
+    // create question
+    await APICreateQuestion(firstQuestion);
+
+    // go to away from the TabNavigator
+    await element(by.id('tabs.chats')).tap();
+    await element(by.id('main.buddylist.kebabicon')).tap();
+    await element(by.text('Banned')).tap();
+    await element(by.id('main.folderedlist.back.button')).tap();
+
+    // the Question is rendered on the Screen
+    const firstText = element(by.text(firstQuestion.rules.titles.en));
+    await expect(firstText).toBeVisible();
+  });
+
+  it('fetches and shows questions when coming from background', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+
+    const firstQuestion = questions[0];
+
+    // mentee sign in
+    await signIn(mentee);
+
+    // Put app on background
+    await device.sendToHome();
+
+    // create question
+    await APICreateQuestion(firstQuestion);
+
+    // bring the app from background
+    await device.launchApp({ newInstance: false });
+
+    // the Question is rendered on the Screen
+    await expect(element(by.text(firstQuestion.rules.titles.en))).toBeVisible();
+  });
 });

--- a/src/Screens/Main/MentorList.tsx
+++ b/src/Screens/Main/MentorList.tsx
@@ -5,12 +5,10 @@ import { SafeAreaView } from 'react-navigation';
 import * as navigationProps from '../../lib/navigation-props';
 
 import * as redux from 'redux';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import * as actions from '../../state/actions';
-import { selectFirstQuestion } from '../../state/reducers/questions';
 
 import * as mentorApi from '../../api/mentors';
-import { Answer } from '../../api/feedback';
 
 import Background from '../components/Background';
 import { textShadow } from '../components/shadow';
@@ -21,7 +19,6 @@ import fonts from '../components/fonts';
 
 import { MentorCardExpandedRoute } from './MentorCardExpanded';
 import { SearchMentorRoute } from '../Main/SearchMentor';
-import QuestionModal from '../components/QuestionModal';
 
 export type MentorListRoute = {
   'Main/MentorList': {};
@@ -35,8 +32,6 @@ type Props = OwnProps;
 
 const MentorList = (props: Props) => {
   const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
-
-  const feedbackQuestion = useSelector(selectFirstQuestion);
 
   const onPressMentor = (mentor: mentorApi.Mentor) => {
     props.navigation.navigate('Main/MentorCardExpanded', {
@@ -57,16 +52,6 @@ const MentorList = (props: Props) => {
     props.navigation.navigate('Main/SearchMentor', {});
   };
 
-  React.useEffect(() => {
-    dispatch({ type: 'feedback/getQuestions/start', payload: undefined });
-  }, []);
-
-  const handleCloseQuestion = () =>
-    dispatch({ type: 'feedback/reset/', payload: undefined });
-
-  const handleAnswer = (answer: Answer) =>
-    dispatch({ type: 'feedback/sendAnswer/start', payload: answer });
-
   return (
     <Background>
       <SafeAreaView
@@ -79,13 +64,6 @@ const MentorList = (props: Props) => {
         />
         <MentorListComponent onPress={onPressMentor} />
         <RN.View style={styles.bottomSeparator} />
-        {feedbackQuestion && (
-          <QuestionModal
-            question={feedbackQuestion}
-            onClose={handleCloseQuestion}
-            onAnswer={handleAnswer}
-          />
-        )}
       </SafeAreaView>
     </Background>
   );


### PR DESCRIPTION
### What has changed?
- fetch questions 
    -  when focusing on MentorList, Settings or Chat ( the main Tabs)
    - when coming back to foreground
- can show questions in any Tab


### Why was the change made?
To fetch questions more actively


### Caveats?
React-navigation 4 does not offer any great hooks or API to use events. It does provide some listeners and  a NavigationEvents component, which provides the same listeners, such as onDidFocus. 

Fetching the data is still not done all the time, but probably enough if focusing one of the three main Tabs is enough to trigger the fetching? It will not trigger fetching if user is never going to the main pages

Also bringing app back to foreground triggers fetching of the questions. Using mutable state for this.

### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/Hjd69LSV/642-fetch-feedback-questions-when-app-is-back-from-background)

### Checklist
- [ ] I have updated relevant documentation in READMES
