### PR TITLE
Fetch mentors more frequently, update buddies

### DIFF
--- a/e2e/browseMentorsTest.spec.ts
+++ b/e2e/browseMentorsTest.spec.ts
@@ -1,18 +1,23 @@
-import { by, element, expect, device } from 'detox';
+import { by, element, expect, device, waitFor } from 'detox';
 import {
   describe,
   it,
   beforeEach,
   beforeAll,
+  afterEach,
   expect as jestExpect,
 } from '@jest/globals';
 
 import {
   APISignUpMentee,
   APIDeleteAccounts,
-  scrollDownAndTap,
   APISignUpMentor,
+  APIGetSendInfo,
+  APISendMessage,
+  APIUpdateMentor,
+  scrollDownAndTap,
   signIn,
+  forceLogout,
 } from './helpers';
 
 const accountFixtures = require('./fixtures/accounts.json');
@@ -24,6 +29,9 @@ describe('Browse mentors', () => {
   beforeEach(async () => {
     await APIDeleteAccounts();
     await device.reloadReactNative();
+  });
+  afterEach(async () => {
+    await forceLogout();
   });
 
   it('without login', async () => {
@@ -104,5 +112,70 @@ describe('Browse mentors', () => {
     await element(by.id('components.mentorTitle.chevronLeft')).tap();
 
     await expect(element(by.id('components.mentorList'))).toBeVisible();
+  });
+
+  it('mentors are updated when user brings app from background', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+    await signIn(mentee);
+
+    await device.sendToHome();
+
+    // create first mentor
+    const mentor1 = accountFixtures.mentors[0];
+    await APISignUpMentor(mentor1);
+
+    await device.launchApp({ newInstance: false });
+
+    await expect(element(by.id('components.mentorList'))).toBeVisible();
+    await expect(
+      element(by.text(accountFixtures.mentors[0].displayName)),
+    ).toBeVisible();
+  });
+
+  it('updates the chat-partner (mentor) name when refetching', async () => {
+    const mentor = accountFixtures.mentors[1];
+    await APISignUpMentor(mentor);
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+
+    // mentee sends a msg to mentor
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      headers: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
+
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi',
+      headers: menteeHeaders,
+    });
+
+    await signIn(mentee);
+
+    await element(by.id('tabs.chats')).tap();
+    await element(by.text(mentor.displayName)).atIndex(0).tap();
+
+    const newDisplayname = 'Updated';
+    const updatedMentor = { ...mentor, displayName: newDisplayname };
+
+    // update mentor
+    await APIUpdateMentor(mentor.displayName, updatedMentor);
+
+    // go to chats
+    await element(by.id('chat.back.button')).tap();
+
+    // the name will change in the chat
+    await waitFor(element(by.text(newDisplayname)).atIndex(0))
+      .toBeVisible()
+      .withTimeout(5000);
+
+    // go to back to the mentors view
+    await element(by.id('tabs.mentors')).tap();
+
+    // Name is changed in mentorList
+    await expect(element(by.text(newDisplayname)).atIndex(0)).toBeVisible();
   });
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -420,3 +420,60 @@ export async function APIDeleteQuestions() {
     });
   }
 }
+
+/**
+ * map to apimentor
+ */
+const toApiMentor = ({
+  birthYear,
+  displayName,
+  story,
+  languages,
+  skills,
+  communication_channels,
+  gender,
+  region,
+}: any) => ({
+  birth_year: birthYear,
+  display_name: displayName,
+  story,
+  languages,
+  skills,
+  communication_channels,
+  gender,
+  region,
+});
+
+/**
+ * Get mentors
+ */
+export const APIMentors = async () => {
+  const mentorsResponse = await fetch(`${API_URL}/mentors`);
+
+  const mentorsJson: any = await mentorsResponse.json();
+
+  return mentorsJson.resources;
+};
+
+/**
+ * Update mentors data
+ */
+export async function APIUpdateMentor(mentorName: string, mentor: any) {
+  const access_token = await APIAdminAccessToken();
+  const mentors = await APIMentors();
+
+  const mentorData = mentors.find((o: any) => o.display_name === mentorName);
+
+  const headers = {
+    Authorization: `Bearer ${access_token}`,
+  };
+
+  const mappedMentorData = toApiMentor(mentor);
+  const updatedMentor = { ...mentorData, ...mappedMentorData };
+
+  await fetch(`${API_URL}/mentors/${mentorData.id}`, {
+    method: 'PUT',
+    headers: headers,
+    body: JSON.stringify(updatedMentor),
+  });
+}

--- a/src/Screens/Main/Chat/Title.tsx
+++ b/src/Screens/Main/Chat/Title.tsx
@@ -49,7 +49,11 @@ const Title: React.FC<Props> = ({
     >
       <SafeAreaView style={styles.safeArea} forceInset={{ top: 'always' }}>
         {!onPress ? null : (
-          <RN.TouchableOpacity style={styles.chevronButton} onPress={onPress}>
+          <RN.TouchableOpacity
+            style={styles.chevronButton}
+            onPress={onPress}
+            testID={'chat.back.button'}
+          >
             <RN.Image
               source={require('../../images/chevron-left.svg')}
               style={styles.chevronIcon}

--- a/src/Screens/Main/Tabs.tsx
+++ b/src/Screens/Main/Tabs.tsx
@@ -76,9 +76,10 @@ const TabBar = ({
 
   const appState = React.useRef(RN.AppState.currentState);
 
-  const handleFetchQuestions = () =>
+  const handleRefetchData = () => {
     dispatch({ type: 'feedback/getQuestions/start', payload: undefined });
-
+    dispatch({ type: 'mentors/start', payload: undefined });
+  };
   const feedbackQuestion = ReactRedux.useSelector(selectFirstQuestion);
 
   const handleCloseQuestion = () =>
@@ -92,7 +93,7 @@ const TabBar = ({
       'change',
       nextAppState => {
         if (nextAppState === 'active') {
-          handleFetchQuestions();
+          handleRefetchData();
         }
 
         appState.current = nextAppState;
@@ -139,7 +140,7 @@ const TabBar = ({
             </RN.View>
           );
         })}
-        <NavigationEvents onDidFocus={handleFetchQuestions} />
+        <NavigationEvents onDidFocus={handleRefetchData} />
       </SafeAreaView>
     </RN.View>
   );

--- a/src/state/reducers/buddies.ts
+++ b/src/state/reducers/buddies.ts
@@ -136,6 +136,29 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       return state;
     }
 
+    case 'mentors/end': {
+      if (E.isRight(action.payload) && RD.isSuccess(state.buddies)) {
+        const mentors = action.payload.right;
+        const stateBuddies = state.buddies.value;
+        const buddyIds = Object.keys(stateBuddies);
+
+        const nextBuddies = buddyIds.reduce<Record<string, buddyApi.Buddy>>(
+          (buddies, id) => {
+            const updatedBuddy = mentors[id]
+              ? { ...stateBuddies[id], name: mentors[id].name }
+              : stateBuddies[id];
+
+            return { ...buddies, [id]: updatedBuddy };
+          },
+          {},
+        );
+
+        return { ...state, buddies: RD.success(nextBuddies) };
+      }
+
+      return state;
+    }
+
     default:
       return state;
   }


### PR DESCRIPTION
### What has changed?
Fetch mentors more frequently:
    - when bringing app from background to foreground
    - when focusing on the main-tab navigator
    
  Now we have two data's refreshed in the same manner (feedbackQuestions, mentors)
  
   
 When doing this I found out a bug in the application. 
 
 The mentors-data and buddies-data is separate, and it was not in sync. 
 This caused a problem when refreshing mentors-data: if mentor updated their display_name, then it would not show to existing buddies until next login. 
We want to keep buddies/mentors -names in sync.
This probably is not a problem atm, because we dont refresh the data anyway. 
 I made the fix in this same PR (buddies-reducer)


### Why was the change made?
We want to the app to be more responsive and up to date, now that the Web-application is coming, we want to improve the mobile app UX too.


### Caveats?
The code to fix the bug is not beautifully functional. It is readable though, and what I managed to do in this time constraint.


### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/q9DH2DBC/603-fetch-mentor-data-more-often)

### Checklist
- [x] I have updated relevant documentation in READMES
