### PR TITLE
Add missing feedback-properties for e2e-fixtures

### DIFF
--- a/e2e/fixtures/questions.ts
+++ b/e2e/fixtures/questions.ts
@@ -26,6 +26,7 @@ export const questions = [
       },
       schedule: {
         remind_times_when_skipped: 3,
+        remind_interval_days: 1,
         first: {
           days_since_registration: 0,
           sent_messages_threshold: 0,
@@ -59,6 +60,7 @@ export const questions = [
       },
       schedule: {
         remind_times_when_skipped: 0,
+        remind_interval_days: 1,
         first: {
           days_since_registration: 0,
           sent_messages_threshold: 0,

--- a/e2e/fixtures/questions.ts
+++ b/e2e/fixtures/questions.ts
@@ -1,6 +1,7 @@
 export const questions = [
   {
     rules: {
+      recipients: ['mentee'],
       titles: {
         fi: 'Kun ajattelet nykyhetkeä, kuinka tyytyväinen olet luottamuksellisiin ihmissuhteisiisi?',
         en: 'When you think about the present, how satisfied are you with your confidential relationships?',
@@ -40,6 +41,7 @@ export const questions = [
   },
   {
     rules: {
+      recipients: ['mentee'],
       titles: {
         fi: 'Oletko saanut apua mentorilta?',
         en: 'Have you received help from a mentor?',


### PR DESCRIPTION
### What has changed?
Added "recipients"-array and "remind_interval_days"-value to the questions in the e2e - fixtures


### Why was the change made?
To fix the feedback e2e-tests 

### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/GuprGKwI/711-fix-feedback-e2e-tests)

### Checklist
- [ ] I have updated relevant documentation in READMES
- [x] I ran the e2e tests successfully on iPhone 11 simulator
