### PR TITLE
Add rn-slider to Podfile.lock

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -332,6 +332,8 @@ PODS:
     - glog
   - react-native-safe-area-context (3.1.9):
     - React-Core
+  - react-native-slider (4.2.1):
+    - React-Core
   - React-perflogger (0.66.1)
   - React-RCTActionSheet (0.66.1):
     - React-Core/RCTActionSheetHeaders (= 0.66.1)
@@ -460,6 +462,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - "react-native-slider (from `../node_modules/@react-native-community/slider`)"
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -545,6 +548,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-slider:
+    :path: "../node_modules/@react-native-community/slider"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -628,6 +633,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 8c0517dee5e8c70cd6c3066f20213ff7ce54f176
   React-logger: bfddd3418dc1d45b77b822958f3e31422e2c179b
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94
+  react-native-slider: 241935e3ea8e47599c317f512f96ee8de607d4cb
   React-perflogger: fcac6090a80e3d967791b4c7f1b1a017f9d4a398
   React-RCTActionSheet: caf5913d9f9e605f5467206cf9d1caa6d47d7ad6
   React-RCTAnimation: 6539e3bf594f6a529cd861985ba6548286ae1ead

--- a/ios/ylitse.xcodeproj/project.pbxproj
+++ b/ios/ylitse.xcodeproj/project.pbxproj
@@ -677,7 +677,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -743,7 +743,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@devexperts/remote-data-ts": "2.0.4",
         "@react-native-async-storage/async-storage": "1.13.2",
         "@react-native-community/masked-view": "0.1.10",
-        "@react-native-community/slider": "^4.2.1",
+        "@react-native-community/slider": "4.2.1",
         "@react-native-firebase/app": "10.1.0",
         "@react-native-firebase/messaging": "10.1.1",
         "fp-ts": "2.9.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@devexperts/remote-data-ts": "2.0.4",
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/masked-view": "0.1.10",
-    "@react-native-community/slider": "^4.2.1",
+    "@react-native-community/slider": "4.2.1",
     "@react-native-firebase/app": "10.1.0",
     "@react-native-firebase/messaging": "10.1.1",
     "fp-ts": "2.9.1",


### PR DESCRIPTION
### What has changed?
Library was missing from Podfile.lock, so add it there
Also pin the version in package.json by removing hat^


### Why was the change made?
We want to have the deps in the lockfile, so we install correct versions of the libraries. 



### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/UAITUTRe/718-add-rn-community-slider-pod-to-podfilelock)

### Checklist
- [ ] I have updated relevant documentation in READMES
