### PR TITLE
Hide Delete-button if user is a mentor

### DIFF
--- a/src/Screens/Main/Settings/BottomCard.tsx
+++ b/src/Screens/Main/Settings/BottomCard.tsx
@@ -56,13 +56,15 @@ export default ({ navigateToDeleteAccount, navigateToLogout }: Props) => {
         messageId="main.settings.other.button.logOut"
         testID="main.settings.other.button.logOut"
       />
-      <MessageButton
-        style={styles.deleteAccountButton}
-        messageStyle={styles.buttonText}
-        onPress={navigateToDeleteAccount}
-        messageId="main.settings.other.button.deleteAccount"
-        testID="main.settings.other.button.deleteAccount"
-      />
+      {!isMentor && (
+        <MessageButton
+          style={styles.deleteAccountButton}
+          messageStyle={styles.buttonText}
+          onPress={navigateToDeleteAccount}
+          messageId="main.settings.other.button.deleteAccount"
+          testID="main.settings.other.button.deleteAccount"
+        />
+      )}
     </Card>
   );
 };


### PR DESCRIPTION
### What has changed?
Hide Delete-button if user is a mentor-user


### Why was the change made?
Mentor users should not delete their accounts themselves, but contact the admin that will then start the process.


### Related Trello issue
Link to the [Trello ticket](https://trello.com/c/1179VRbk/824-remove-delete-account-button-for-mentors)

### Checklist
- [ ] I have updated relevant documentation in READMES
