### PR TITLE
Abort action-loop if one action-loop already pending

### DIFF
--- a/src/Screens/Main/Tabs.tsx
+++ b/src/Screens/Main/Tabs.tsx
@@ -43,7 +43,9 @@ const Main = ({ navigation }: Props) => {
     dispatch({ type: 'feedback/sendAnswer/start', payload: answer });
   };
 
-  useRefetch({ callback: handleRefetchData });
+  useRefetch({
+    callback: handleRefetchData,
+  });
 
   React.useEffect(() => {
     navigation.dispatch(state => {

--- a/src/lib/use-refetch.ts
+++ b/src/lib/use-refetch.ts
@@ -22,11 +22,15 @@ export const useRefetch = ({ callback }: Params) => {
 
   React.useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
-      if (
-        appState.current.match(/inactive|background/) &&
-        nextAppState === 'active'
-      ) {
-        callback();
+      if (nextAppState === 'active') {
+        switch (appState.current) {
+          case 'inactive':
+          case 'background':
+            callback();
+            break;
+          default:
+            break;
+        }
       }
 
       appState.current = nextAppState;

--- a/src/lib/use-refetch.ts
+++ b/src/lib/use-refetch.ts
@@ -23,7 +23,7 @@ export const useRefetch = ({ callback }: Params) => {
   React.useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (
-        appState.current.match(/inacteve|background/) &&
+        appState.current.match(/inactive|background/) &&
         nextAppState === 'active'
       ) {
         callback();

--- a/src/state/reducers/questions.ts
+++ b/src/state/reducers/questions.ts
@@ -19,6 +19,10 @@ export const reducer: Reducer<AppState['feedbackQuestions'], Action> = (
 ) => {
   switch (action.type) {
     case 'feedback/getQuestions/start': {
+      if (RD.isPending(state)) {
+        return state;
+      }
+
       return automaton.loop(
         RD.pending,
         withToken(

--- a/src/state/reducers/questions.ts
+++ b/src/state/reducers/questions.ts
@@ -19,7 +19,7 @@ export const reducer: Reducer<AppState['feedbackQuestions'], Action> = (
 ) => {
   switch (action.type) {
     case 'feedback/getQuestions/start': {
-      if (RD.isPending(state)) {
+      if (RD.isPending(state) || hasUnAnsweredQuestions(state)) {
         return state;
       }
 
@@ -53,13 +53,7 @@ export const reducer: Reducer<AppState['feedbackQuestions'], Action> = (
     }
 
     case 'feedback/sendAnswer/end': {
-      const hasUnAnsweredQuestions = pipe(
-        state,
-        RD.getOrElse<unknown, feedbackApi.Question[]>(() => []),
-        questions => questions.length > 0,
-      );
-
-      if (hasUnAnsweredQuestions) {
+      if (hasUnAnsweredQuestions(state)) {
         return state;
       }
 
@@ -78,6 +72,13 @@ export const reducer: Reducer<AppState['feedbackQuestions'], Action> = (
     }
   }
 };
+
+const hasUnAnsweredQuestions = (state: AppState['feedbackQuestions']) =>
+  pipe(
+    state,
+    RD.getOrElse<unknown, feedbackApi.Question[]>(() => []),
+    questions => questions.length > 0,
+  );
 
 export const selectFirstQuestion = ({
   feedbackQuestions,


### PR DESCRIPTION
### What has changed?
- Abort the action-loop if already pending request or questions in state 


### Why was the change made?
- Bug fix: If user opened application and their token was expired there was a rerender that caused the questions be fetched two times. 
    - First fetch gets questions, and then second one does not (because we only get questions once) 
    - The second response overrides the first one so there is no questions anymore :'(



### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/JkZFmoNm/833-android-investigate-question-disappears-from-screen)

### Checklist
- [x] I have updated relevant documentation in READMES
