### PR TITLE
Fix Splash-navigation causing question disappearing

### DIFF
--- a/src/Screens/Splash/index.tsx
+++ b/src/Screens/Splash/index.tsx
@@ -40,11 +40,9 @@ const Splash = ({ navigation }: Props) => {
 
   React.useEffect(() => {
     if (O.isSome(tokenState)) {
-      setTimeout(() => {
-        navigation.replace('Main/Tabs', {});
-      }, 500);
+      navigation.replace('Main/Tabs', {});
     }
-  });
+  }, [tokenState]);
 
   return <RN.View style={styles.background} />;
 };


### PR DESCRIPTION
### What has changed?
Fixed effect that navigates user to Main/Tabs (main-screen). 
Listen to changes in tokenState-variable, that runs the navigation-effect. No timeout!

### Why was the change made?

Question would disappear in some circumstances: 
- The application was closed
- User had been logged in but the token was expired
- iOS

Then refetching questions would cause a rerender in iOS and hide the question.
Interestingly the application also was unresponsive. User cannot press anything.
I suspect the Modal is left under the view or something.

Rerender was also in Android but would not hide the question, because of different implementation in the native-code ( I guess )


### How was tested

Tested in development but also this following verification

- Pixel 5, Android 13 (release mode)
- iPhone 13 mini, iOS 16.6 (release mode)

1. Log in to the applications and close the applications
2. Create question that will match conditions for the logged in users
3. Wait until token is expired
4. Open the applications and see the questions, no disappearing!


### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/9ZPn9fnU/863-disappearing-bug-persists)

### Checklist
- [x] I have updated relevant documentation in READMES
