### PR TITLE
Add mfa for e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npx detox build --configuration {{target}}
 
 Run the steps described below in three separate terminals.
 
-1. Go to Ylitse API repo and start the backend locally (make sure `admin`
+1. Go to Ylitse [API repo](https://gitlab.com/ylitse/ylitse-api) and start the backend locally (make sure `admin`
    user exists):
 
 ```sh
@@ -146,12 +146,12 @@ make run-standalone
 npx react-native start
 ```
 
-3. And finally run tests (make sure password matches the one configured for
-   the local API, and make sure that config.json _loginUrl_ and _baseUrl_  matches the local API)
+3. And finally run tests (make sure password and the mfa-secret matches the one configured for
+   the local API, and make sure that config.json _loginUrl_ and _baseUrl_  matches the target)
 
 
 ```sh
-YLITSE_API_USER={{userwithadminaccess}} YLITSE_API_PASS={{password}} YLITSE_API_URL="http://127.0.0.1:8080" npx detox test --configuration {{target}}
+YLITSE_API_USER={{userwithadminaccess}} YLITSE_API_PASS={{password}} YLITSE_API_URL="http://127.0.0.1:8080" YLITSE_MFA_SECRET={{mfa_secret}} npx detox test --configuration {{target}}
 ```
 
 Replace the moustached values with your values

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Run the steps described below in three separate terminals.
 
 ```sh
 source env/bin/activate
-make run-standalone
+SAFETY_FEATURE=true make run-standalone
 ```
 
 2. Start the metro bundler 

--- a/e2e/archiveTest.spec.ts
+++ b/e2e/archiveTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device, waitFor } from 'detox';
 import { describe, it, beforeEach } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -11,8 +12,6 @@ import {
   forceLogout,
   APIBan,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Archiving', () => {
   beforeEach(async () => {
@@ -57,7 +56,7 @@ describe('Archiving', () => {
     await element(by.text('Archive chat')).tap();
     await element(by.text('OK')).tap();
 
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Archived')).tap();
@@ -174,7 +173,7 @@ describe('Archiving', () => {
     await element(by.text('OK')).tap();
 
     // mentor should not see mentee's name in archived list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await waitFor(element(by.id('main.folderedlist.back.button')))
       .toBeVisible()
@@ -182,7 +181,7 @@ describe('Archiving', () => {
     await element(by.id('main.folderedlist.back.button')).tap();
 
     // mentor should not see mentee's name in chats list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await forceLogout();
 
@@ -196,16 +195,16 @@ describe('Archiving', () => {
 
     // mentor should not see new message indicator
     await signIn(mentor);
-    await expect(element(by.id('main.tabs.unseenDot'))).toBeNotVisible();
+    await expect(element(by.id('main.tabs.unseenDot'))).not.toBeVisible();
     await element(by.id('tabs.chats')).tap();
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Archived')).tap();
     await expect(
       element(by.id('main.buddyList.button.unseenDot')),
-    ).toBeNotVisible();
+    ).not.toBeVisible();
 
     // mentor should not see mentee's name in chats list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await forceLogout();
   });

--- a/e2e/banTest.spec.ts
+++ b/e2e/banTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device, waitFor } from 'detox';
 import { describe, it, beforeEach } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -11,8 +12,6 @@ import {
   forceLogout,
   APIBan,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Banning', () => {
   beforeEach(async () => {
@@ -57,7 +56,7 @@ describe('Banning', () => {
     await element(by.text('Ban chat')).tap();
     await element(by.text('OK')).tap();
 
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Banned')).tap();
@@ -76,13 +75,13 @@ describe('Banning', () => {
 
     // mentor should not see new message indicator
     await signIn(mentor);
-    await expect(element(by.id('main.tabs.unseenDot'))).toBeNotVisible();
+    await expect(element(by.id('main.tabs.unseenDot'))).not.toBeVisible();
     await element(by.id('tabs.chats')).tap();
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Banned')).tap();
     await expect(
       element(by.id('main.buddyList.button.unseenDot')),
-    ).toBeNotVisible();
+    ).not.toBeVisible();
 
     // but new msg should still be there
     await element(by.text(mentee.displayName)).atIndex(0).tap();
@@ -171,7 +170,7 @@ describe('Banning', () => {
     await element(by.text('OK')).tap();
 
     // mentor should not see mentee's name in banned list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await waitFor(element(by.id('main.folderedlist.back.button')))
       .toBeVisible()
@@ -179,7 +178,7 @@ describe('Banning', () => {
     await element(by.id('main.folderedlist.back.button')).tap();
 
     // mentor should not see mentee's name in chats list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await forceLogout();
 
@@ -193,16 +192,16 @@ describe('Banning', () => {
 
     // mentor should not see new message indicator
     await signIn(mentor);
-    await expect(element(by.id('main.tabs.unseenDot'))).toBeNotVisible();
+    await expect(element(by.id('main.tabs.unseenDot'))).not.toBeVisible();
     await element(by.id('tabs.chats')).tap();
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Banned')).tap();
     await expect(
       element(by.id('main.buddyList.button.unseenDot')),
-    ).toBeNotVisible();
+    ).not.toBeVisible();
 
     // mentor should not see mentee's name in chats list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await forceLogout();
   });
@@ -257,8 +256,8 @@ describe('Banning', () => {
     await element(by.text('OK')).tap();
 
     // mentor should not see mentees' names in banned list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
-    await expect(element(by.text(mentee2.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
+    await expect(element(by.text(mentee2.displayName))).not.toBeVisible();
 
     await waitFor(element(by.id('main.folderedlist.back.button')))
       .toBeVisible()
@@ -266,8 +265,8 @@ describe('Banning', () => {
     await element(by.id('main.folderedlist.back.button')).tap();
 
     // mentor should not see mentees' names in chats list
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
-    await expect(element(by.text(mentee2.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
+    await expect(element(by.text(mentee2.displayName))).not.toBeVisible();
 
     await forceLogout();
   });

--- a/e2e/browseMentorsTest.spec.ts
+++ b/e2e/browseMentorsTest.spec.ts
@@ -7,6 +7,7 @@ import {
   afterEach,
   expect as jestExpect,
 } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -19,8 +20,6 @@ import {
   signIn,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Browse mentors', () => {
   beforeAll(async () => {

--- a/e2e/changeEmailTest.spec.ts
+++ b/e2e/changeEmailTest.spec.ts
@@ -8,8 +8,7 @@ import {
   signIn,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
+import accountFixtures from './fixtures/accounts.json';
 
 describe('changeEmail', () => {
   beforeAll(async () => {
@@ -32,7 +31,7 @@ describe('changeEmail', () => {
 
     await element(by.id('main.settings.account.email.input')).clearText();
     await waitAndTypeText('main.settings.account.email.input', newEmail);
-    await expect(element(by.text('Invalid email address'))).toBeNotVisible();
+    await expect(element(by.text('Invalid email address'))).not.toBeVisible();
     await element(by.id('main.settings.account.email.save')).tap();
     await expect(element(by.text(newEmail))).toBeVisible();
   });

--- a/e2e/changePasswordTest.spec.ts
+++ b/e2e/changePasswordTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -10,8 +11,6 @@ import {
   scrollUpTo,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('changePassword', () => {
   beforeAll(async () => {

--- a/e2e/chatListNavigationTest.spec.ts
+++ b/e2e/chatListNavigationTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -11,8 +12,6 @@ import {
   forceLogout,
   APIBan,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Navigate in chat views', () => {
   beforeAll(async () => {
@@ -75,7 +74,7 @@ describe('Navigate in chat views', () => {
 
     await element(by.id('tabs.chats')).tap();
 
-    await expect(element(by.text(mentee.displayName))).toBeNotVisible();
+    await expect(element(by.text(mentee.displayName))).not.toBeVisible();
 
     await element(by.id('main.buddylist.kebabicon')).tap();
     await element(by.text('Banned')).tap();

--- a/e2e/chatTest.spec.ts
+++ b/e2e/chatTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, device, expect } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -9,8 +10,6 @@ import {
   signIn,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Chat', () => {
   beforeAll(async () => {

--- a/e2e/deleteAccountTest.spec.ts
+++ b/e2e/deleteAccountTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -7,8 +8,6 @@ import {
   scrollDownAndTap,
   signIn,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Delete account', () => {
   beforeAll(async () => {

--- a/e2e/feedback.spec.ts
+++ b/e2e/feedback.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, afterAll, afterEach } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -11,8 +12,6 @@ import {
 } from './helpers';
 
 import { questions } from './fixtures/questions';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Feedback', () => {
   afterAll(async () => {

--- a/e2e/filterSkillTest.spec.ts
+++ b/e2e/filterSkillTest.spec.ts
@@ -6,6 +6,7 @@ import {
   beforeAll,
   expect as jestExpect,
 } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -15,8 +16,6 @@ import {
   waitAndTypeText,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Skill filter', () => {
   beforeAll(async () => {
@@ -136,7 +135,7 @@ describe('Skill filter', () => {
       element(
         by.text('python').withAncestor(by.id('main.searchMentor.skills.view')),
       ),
-    ).toBeNotVisible();
+    ).not.toBeVisible();
   });
 
   it('reset search shows all skills', async () => {
@@ -165,7 +164,7 @@ describe('Skill filter', () => {
       element(
         by.text('python').withAncestor(by.id('main.searchMentor.skills.view')),
       ),
-    ).toBeNotVisible();
+    ).not.toBeVisible();
 
     await element(by.id('main.searchMentor.resetButton')).tap();
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -147,6 +147,7 @@ export async function APIAccessToken(
   mfaSecret?: string,
 ) {
   const newSecret = generateToken(mfaSecret ?? '');
+
   const loginResponse = await fetch(`${API_URL}/login`, {
     method: 'POST',
     body: JSON.stringify({

--- a/e2e/hideInactiveMentorsTest.spec.ts
+++ b/e2e/hideInactiveMentorsTest.spec.ts
@@ -6,6 +6,7 @@ import {
   beforeAll,
   expect as jestExpect,
 } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -15,16 +16,14 @@ import {
   forceLogout,
 } from './helpers';
 
-const accountFixtures = require('./fixtures/accounts.json');
-
 const findMentor = async (mentorIndexes: any, mentorsFound: any) => {
   let found = { ...mentorsFound };
   for (let i in mentorIndexes) {
     try {
       await expect(
-        element(by.text(accountFixtures.mentors[i].displayName)),
+        element(by.text(accountFixtures.mentors[Number(i)].displayName)),
       ).toBeVisible();
-      found[accountFixtures.mentors[i].displayName] = true;
+      found[accountFixtures.mentors[Number(i)].displayName] = true;
     } catch (error) {
       continue;
     }

--- a/e2e/init.ts
+++ b/e2e/init.ts
@@ -9,7 +9,7 @@ j.beforeAll(async () => {
     await APIAdminAccessToken();
   } catch (error) {
     console.error(
-      'Cannot connect to YLITSE API. YLITSE_API_USER=... YLITSE_API_PASS=... YLITSE_API_URL=...',
+      'Cannot connect to YLITSE API. YLITSE_API_PASS=... YLITSE_MFA_SECRET=...',
     );
     process.exitCode = 1;
     throw error;

--- a/e2e/logoutTest.spec.ts
+++ b/e2e/logoutTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -8,8 +9,6 @@ import {
   scrollDownAndTap,
   signIn,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Delete', () => {
   beforeAll(async () => {

--- a/e2e/signInTest.spec.ts
+++ b/e2e/signInTest.spec.ts
@@ -1,9 +1,8 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import { APISignUpMentee, APIDeleteAccounts, signIn } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('SignIn', () => {
   beforeAll(async () => {

--- a/e2e/signUpTest.spec.ts
+++ b/e2e/signUpTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APIDeleteAccounts,
@@ -7,8 +8,6 @@ import {
   waitAndTypeText,
   forceLogout,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('SignUp', () => {
   beforeAll(async () => {

--- a/e2e/statusMessageTest.spec.ts
+++ b/e2e/statusMessageTest.spec.ts
@@ -6,6 +6,7 @@ import {
   beforeAll,
   expect as jestExpect,
 } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentor,
@@ -15,8 +16,6 @@ import {
   forceLogout,
   scrollDownAndTap,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('Show status message', () => {
   beforeAll(async () => {
@@ -41,6 +40,7 @@ describe('Show status message', () => {
     // Show status message in mentor list...
     await expect(element(by.id('components.mentorList'))).toBeVisible();
 
+    //@ts-ignore
     const statusMessages: Record<string, string> = {
       [mentor1.displayName]: mentor1.status_message,
       [mentor2.displayName]: mentor2.status_message,
@@ -99,6 +99,7 @@ describe('Change status message', () => {
       'main.settings.account.status.title',
       'main.settings.index.view',
     );
+    // @ts-ignore
     await expect(element(by.text(mentor.status_message))).toBeVisible();
 
     await element(by.id('main.settings.account.status.input')).clearText();

--- a/e2e/userReportTest.spec.ts
+++ b/e2e/userReportTest.spec.ts
@@ -1,5 +1,6 @@
 import { by, element, expect, device } from 'detox';
 import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
@@ -11,8 +12,6 @@ import {
   forceLogout,
   waitAndTypeText,
 } from './helpers';
-
-const accountFixtures = require('./fixtures/accounts.json');
 
 describe('reportUser', () => {
   beforeAll(async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "jest": "29.5.0",
         "jest-circus": "29.5.0",
         "metro-react-native-babel-preset": "0.76.1",
+        "node-2fa": "^2.0.3",
         "prettier": "2.8.7",
         "react-native-svg-asset-plugin": "0.5.0",
         "react-test-renderer": "18.2.0",
@@ -4709,6 +4710,15 @@
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
       "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q=="
+    },
+    "node_modules/@types/notp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/notp/-/notp-2.0.3.tgz",
+      "integrity": "sha512-biFO/VNDdq/vH7PVN+WovqxhbRhvaA2daj1uAvMFKrcMQ12tfoSySud3vV8m9Zls6eM2FC8N9CpKbkLYJS1AAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -13653,6 +13663,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/node-2fa": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/node-2fa/-/node-2fa-2.0.3.tgz",
+      "integrity": "sha512-PQldrOhjuoZyoydMvMSctllPN1ZPZ1/NwkEcgYwY9faVqE/OymxR+3awPpbWZxm6acLKqvmNqQmdqTsqYyflFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/notp": "^2.0.0",
+        "notp": "^2.0.3",
+        "thirty-two": "1.0.2",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.33.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
@@ -13758,6 +13780,15 @@
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/notp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/notp/-/notp-2.0.3.tgz",
+      "integrity": "sha512-oBig/2uqkjQ5AkBuw4QJYwkEWa/q+zHxI5/I5z6IeP2NT0alpJFsP/trrfCC+9xOAgQSZXssNi962kp5KBmypQ==",
+      "dev": true,
+      "engines": {
+        "node": "> v0.6.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -16682,6 +16713,15 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.2.6"
+      }
     },
     "node_modules/throat": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "jest": "29.5.0",
     "jest-circus": "29.5.0",
     "metro-react-native-babel-preset": "0.76.1",
+    "node-2fa": "^2.0.3",
     "prettier": "2.8.7",
     "react-native-svg-asset-plugin": "0.5.0",
     "react-test-renderer": "18.2.0",


### PR DESCRIPTION
### What has changed?
- Added mfa token in e2e test setup using [node-2fa](https://www.npmjs.com/package/node-2fa)
- Fixed some depreactions in e2e suite
- Updated readme


### Why was the change made?
Mfa is now required for all admin users. This means that we need to have mfa-token in the e2e tests when we are setting the state for the tests.

### Caveats
- One new development dependency

### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/YHnwNMLS/867-fix-e2e-test-to-work-with-mfa)

### Checklist
- [x] I have updated relevant documentation in READMES
