### PR TITLE
Increase success-toast timeout to be 5000ms

### DIFF
--- a/src/state/reducers/userReport.ts
+++ b/src/state/reducers/userReport.ts
@@ -10,7 +10,7 @@ import * as T from 'fp-ts/lib/Task';
 import * as userReportApi from '../../api/userReport';
 
 export const initialState = RD.initial;
-export const coolDownDuration = 3000;
+export const coolDownDuration = 5000;
 
 export const reducer: automaton.Reducer<
   RD.RemoteData<string, true>,


### PR DESCRIPTION
### What has changed?
Increaseds time to show success-toast after a successfull user-reporting action


### Why was the change made?
Text is so long that users might need more time to read the toast

### Video of the 5s toast

https://github.com/sos-lapsikyla/ylitse-app/assets/34128180/b00b4fa1-ae1e-4877-8022-3d216c02a334




### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/9HlKIy7J/883-increase-time-to-show-toast-on-successfull-user-report-action)

### Checklist
- [ ] I have updated relevant documentation in READMES
