### PR TITLE
Bump version to 2.12.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,8 +106,8 @@ android {
         applicationId "com.ylitse"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 45
-        versionName "2.11.0"
+        versionCode 46
+        versionName "2.12.0"
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/ios/ylitse.xcodeproj/project.pbxproj
+++ b/ios/ylitse.xcodeproj/project.pbxproj
@@ -596,7 +596,7 @@
 				CODE_SIGN_ENTITLEMENTS = ylitse/ylitse.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = L4F7DPRAF7;
 				INFOPLIST_FILE = ylitse/Info.plist;
@@ -604,7 +604,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.11.0;
+				MARKETING_VERSION = 2.12.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -629,14 +629,14 @@
 				CODE_SIGN_ENTITLEMENTS = ylitse/ylitse.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 45;
+				CURRENT_PROJECT_VERSION = 46;
 				DEVELOPMENT_TEAM = L4F7DPRAF7;
 				INFOPLIST_FILE = ylitse/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.11.0;
+				MARKETING_VERSION = 2.12.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
### What has changed?
Version from 2.11.0 -> 2.12.0


### Why was the change made?
- For release to stores


### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/i0BmyizD/890-release-v2120)

### Checklist
- [ ] I have updated relevant documentation in READMES
