### PR TITLE
Improve mark-seen-logic

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -20,7 +20,7 @@ module.exports = {
       type: 'ios.app',
       binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/ylitse.app',
       build:
-        "xcodebuild -workspace ios/ylitse.xcworkspace -configuration Debug -scheme ylitse -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.4' -derivedDataPath ios/build",
+        "xcodebuild -workspace ios/ylitse.xcworkspace -configuration Debug -scheme ylitse -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.2' -derivedDataPath ios/build",
     },
     'android.debug': {
       type: 'android.apk',
@@ -32,7 +32,7 @@ module.exports = {
   devices: {
     'ios.simulator': {
       type: 'ios.simulator',
-      device: { type: 'iPhone 14' },
+      device: { type: 'iPhone 15' },
     },
     'android.emulator': {
       type: 'android.emulator',

--- a/e2e/chatTest.spec.ts
+++ b/e2e/chatTest.spec.ts
@@ -5,10 +5,7 @@ import accountFixtures from './fixtures/accounts.json';
 import {
   APISignUpMentee,
   APISignUpMentor,
-  APIGetSendInfo,
-  APISendMessage,
   APIDeleteAccounts,
-  APIDeleteAccount,
   waitAndTypeText,
   signIn,
   forceLogout,
@@ -24,7 +21,7 @@ describe('Chat', () => {
     await device.reloadReactNative();
   });
 
-  xit('with new mentor', async () => {
+  it('with new mentor', async () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
     const mentor = accountFixtures.mentors[0];
@@ -61,48 +58,5 @@ describe('Chat', () => {
 
     await expect(element(by.text(message_from_mentee))).toBeVisible();
     await expect(element(by.text(message_from_mentor))).toBeVisible();
-  });
-
-  it('if buddy with most recent message deletes account, can receive still messages from other users', async () => {
-    const mentee = accountFixtures.mentees[0];
-    await APISignUpMentee(mentee);
-    const mentor = accountFixtures.mentors[0];
-    await APISignUpMentor(mentor);
-
-    // mentee sends a msg to mentor
-    const {
-      sender_id: menteeId,
-      sender_info: mentee_info,
-      recipient_id: mentorId,
-      senderHeaders: menteeHeaders,
-    } = await APIGetSendInfo(mentee, mentor);
-    await APISendMessage({
-      sender_id: menteeId,
-      recipient_id: mentorId,
-      content: 'Hi first',
-      headers: menteeHeaders,
-    });
-
-    await signIn(mentor);
-    await element(by.id('tabs.chats')).tap();
-    await element(by.text(mentee.displayName)).tap();
-    await element(by.id('chat.back.button')).tap();
-
-    // delete mentee account
-    await APIDeleteAccount(mentee_info.account_id, menteeHeaders)
-
-    // new mentee
-    const newMentee = accountFixtures.mentees[1];
-    await APISignUpMentee(newMentee);
-    const {
-      sender_id: newMenteeId,
-      senderHeaders: newMenteeHeaders,
-    } = await APIGetSendInfo(newMentee, mentor);
-    await APISendMessage({
-      sender_id: newMenteeId,
-      recipient_id: mentorId,
-      content: 'Hi second',
-      headers: newMenteeHeaders,
-    });
   });
 });

--- a/e2e/chatTest.spec.ts
+++ b/e2e/chatTest.spec.ts
@@ -5,7 +5,10 @@ import accountFixtures from './fixtures/accounts.json';
 import {
   APISignUpMentee,
   APISignUpMentor,
+  APIGetSendInfo,
+  APISendMessage,
   APIDeleteAccounts,
+  APIDeleteAccount,
   waitAndTypeText,
   signIn,
   forceLogout,
@@ -21,7 +24,7 @@ describe('Chat', () => {
     await device.reloadReactNative();
   });
 
-  it('with new mentor', async () => {
+  xit('with new mentor', async () => {
     const mentee = accountFixtures.mentees[0];
     await APISignUpMentee(mentee);
     const mentor = accountFixtures.mentors[0];
@@ -58,5 +61,48 @@ describe('Chat', () => {
 
     await expect(element(by.text(message_from_mentee))).toBeVisible();
     await expect(element(by.text(message_from_mentor))).toBeVisible();
+  });
+
+  it('if buddy with most recent message deletes account, can receive still messages from other users', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+    const mentor = accountFixtures.mentors[0];
+    await APISignUpMentor(mentor);
+
+    // mentee sends a msg to mentor
+    const {
+      sender_id: menteeId,
+      sender_info: mentee_info,
+      recipient_id: mentorId,
+      senderHeaders: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
+    await APISendMessage({
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      content: 'Hi first',
+      headers: menteeHeaders,
+    });
+
+    await signIn(mentor);
+    await element(by.id('tabs.chats')).tap();
+    await element(by.text(mentee.displayName)).tap();
+    await element(by.id('chat.back.button')).tap();
+
+    // delete mentee account
+    await APIDeleteAccount(mentee_info.account_id, menteeHeaders)
+
+    // new mentee
+    const newMentee = accountFixtures.mentees[1];
+    await APISignUpMentee(newMentee);
+    const {
+      sender_id: newMenteeId,
+      senderHeaders: newMenteeHeaders,
+    } = await APIGetSendInfo(newMentee, mentor);
+    await APISendMessage({
+      sender_id: newMenteeId,
+      recipient_id: mentorId,
+      content: 'Hi second',
+      headers: newMenteeHeaders,
+    });
   });
 });

--- a/e2e/chatTest.spec.ts
+++ b/e2e/chatTest.spec.ts
@@ -1,24 +1,26 @@
 import { by, element, device, expect } from 'detox';
-import { describe, it, beforeEach, beforeAll } from '@jest/globals';
+import { describe, it, beforeEach, expect as jestExpect } from '@jest/globals';
 import accountFixtures from './fixtures/accounts.json';
 
 import {
   APISignUpMentee,
   APISignUpMentor,
+  APIGetSendInfo,
   APIDeleteAccounts,
+  APISendMessage,
   waitAndTypeText,
   signIn,
   forceLogout,
+  detoxElementCount,
 } from './helpers';
 
 describe('Chat', () => {
-  beforeAll(async () => {
-    await device.launchApp();
-    jest.setTimeout(200000);
-  });
   beforeEach(async () => {
     await APIDeleteAccounts();
     await device.reloadReactNative();
+  });
+  afterEach(async () => {
+    await forceLogout();
   });
 
   it('with new mentor', async () => {
@@ -32,8 +34,8 @@ describe('Chat', () => {
 
     await signIn(mentee);
 
-    await element(by.text('Show mentor')).tap();
-    await element(by.text('Chat')).tap();
+    await element(by.id('components.mentorCard.readMore')).tap();
+    await element(by.id('main.mentorCardExpanded.button')).tap();
 
     await waitAndTypeText('main.chat.input.input', message_from_mentee, true);
     await element(by.id('main.chat.input.button')).tap();
@@ -58,5 +60,85 @@ describe('Chat', () => {
 
     await expect(element(by.text(message_from_mentee))).toBeVisible();
     await expect(element(by.text(message_from_mentor))).toBeVisible();
+  });
+
+  const sendMultiple = async (
+    from: string,
+    to: string,
+    headers: { Authorization: string },
+    content: string,
+    amount: number,
+  ) => {
+    for (let i = 0; i < amount; i++) {
+      await APISendMessage({
+        sender_id: from,
+        recipient_id: to,
+        content: `${content} ${i}`,
+        headers,
+      });
+    }
+  };
+
+  it('marks message unseen', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+    const mentee2 = accountFixtures.mentees[1];
+    await APISignUpMentee(mentee2);
+    const mentor = accountFixtures.mentors[0];
+    await APISignUpMentor(mentor);
+
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      senderHeaders: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
+    await sendMultiple(menteeId, mentorId, menteeHeaders, 'Hello', 5);
+
+    const { sender_id: mentee2Id, senderHeaders: mentee2Headers } =
+      await APIGetSendInfo(mentee2, mentor);
+    await sendMultiple(mentee2Id, mentorId, mentee2Headers, 'Hello', 10);
+
+    await signIn(mentor);
+    await element(by.id('tabs.chats')).tap();
+
+    const unseenDotsAmountBefore = await detoxElementCount(
+      by.id('main.buddyList.button.unseenDot'),
+    );
+    jestExpect(unseenDotsAmountBefore).toBe(2);
+
+    await element(by.text(mentee.displayName)).tap();
+    await expect(element(by.text('Hello 0'))).toBeVisible();
+    await expect(element(by.text('Hello 4'))).toBeVisible();
+
+    await element(by.id('chat.back.button')).tap();
+
+    const unseenDotsAmountAfter = await detoxElementCount(
+      by.id('main.buddyList.button.unseenDot'),
+    );
+    jestExpect(unseenDotsAmountAfter).toBe(1);
+  });
+
+  it('marks message unseen only if fully visible', async () => {
+    const mentee = accountFixtures.mentees[0];
+    await APISignUpMentee(mentee);
+    const mentor = accountFixtures.mentors[0];
+    await APISignUpMentor(mentor);
+
+    const {
+      sender_id: menteeId,
+      recipient_id: mentorId,
+      senderHeaders: menteeHeaders,
+    } = await APIGetSendInfo(mentee, mentor);
+    await sendMultiple(menteeId, mentorId, menteeHeaders, 'Hello', 10);
+
+    await signIn(mentor);
+    await element(by.id('tabs.chats')).tap();
+    await element(by.text(mentee.displayName)).tap();
+
+    await expect(element(by.text('Hello 0'))).not.toBeVisible();
+    await expect(element(by.text('Hello 9'))).toBeVisible();
+
+    await element(by.id('chat.back.button')).tap();
+    await expect(element(by.id('main.tabs.unseenDot'))).toBeVisible();
   });
 });

--- a/e2e/fixtures/accounts.json
+++ b/e2e/fixtures/accounts.json
@@ -9,9 +9,16 @@
         },
         {
             "loginName": "mentee1",
-            "displayName": "mentee1_nick",
+            "displayName": "mentee_mummo",
             "password": "Menteementee!",
             "email": "mentee1@mentee.mentee",
+            "role": "mentee"
+        },
+        {
+            "loginName": "mentee2",
+            "displayName": "mentee_seppo",
+            "password": "Menteementee!",
+            "email": "mentee2@mentee.mentee",
             "role": "mentee"
         }
     ],

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -67,6 +67,18 @@ export async function scrollUpTo(elementId: string, viewId: string) {
 }
 
 /**
+ * Scrolls view up until element with text is found
+ */
+export async function scrollUpAndFindText(text: string, viewId: string) {
+  await waitFor(element(by.text(text)))
+    .toBeVisible()
+    .whileElement(by.id(viewId))
+    // Needs to scroll from x=0.1, y=0.2
+    // because of the big sticky toolbar
+    .scroll(100, 'up', 0.1, 0.2);
+}
+
+/**
  * Waits until input is visible and then types given text
  */
 export async function waitAndTypeText(
@@ -523,7 +535,7 @@ export async function APIUpdateMentor(mentorName: string, mentor: any) {
   });
 }
 
-export async function detoxElementCount(matcher: NativeMatcher) {
+export async function countElements(matcher: NativeMatcher) {
   try {
     const attributes = await element(matcher)?.getAttributes();
 
@@ -535,4 +547,10 @@ export async function detoxElementCount(matcher: NativeMatcher) {
   } catch (e) {
     return 0;
   }
+}
+
+export async function sleep(seconds: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, seconds * 1000);
+  });
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -209,6 +209,17 @@ export async function APIDeleteAccounts() {
 }
 
 /**
+ * Makes HTTP API calls to delete user
+ */
+export async function APIDeleteAccount(id: string, headers: Record<string, string>) {
+  
+    await fetch(`${API_URL}/accounts/${id}`, {
+      method: 'DELETE',
+      headers,
+    });
+}
+
+/**
  * SignUp new mentee
  */
 export async function APISignUpMentee(mentee: any) {
@@ -370,6 +381,7 @@ export async function APIGetSendInfo(sender: any, reciever: any) {
 
   return {
     sender_id: senderInfo.id,
+    sender_info: senderInfo,
     recipient_id: recieverInfo.id,
     senderHeaders: toHeader(accessTokenSender),
     recieverHeaders: toHeader(accessTokenReciever),

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -211,12 +211,14 @@ export async function APIDeleteAccounts() {
 /**
  * Makes HTTP API calls to delete user
  */
-export async function APIDeleteAccount(id: string, headers: Record<string, string>) {
-  
-    await fetch(`${API_URL}/accounts/${id}`, {
-      method: 'DELETE',
-      headers,
-    });
+export async function APIDeleteAccount(
+  id: string,
+  headers: Record<string, string>,
+) {
+  await fetch(`${API_URL}/accounts/${id}`, {
+    method: 'DELETE',
+    headers,
+  });
 }
 
 /**

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import { by, element, waitFor, device } from 'detox';
+import { NativeMatcher } from 'detox/detox';
 import { generateToken } from 'node-2fa';
 
 const API_URL = process.env.YLITSE_API_URL || 'http://127.0.0.1:8080';
@@ -520,4 +521,18 @@ export async function APIUpdateMentor(mentorName: string, mentor: any) {
     headers: headers,
     body: JSON.stringify(updatedMentor),
   });
+}
+
+export async function detoxElementCount(matcher: NativeMatcher) {
+  try {
+    const attributes = await element(matcher)?.getAttributes();
+
+    if ('elements' in attributes) {
+      return attributes.elements.length;
+    } else {
+      return 1;
+    }
+  } catch (e) {
+    return 0;
+  }
 }

--- a/e2e/statusMessageTest.spec.ts
+++ b/e2e/statusMessageTest.spec.ts
@@ -96,7 +96,7 @@ describe('Change status message', () => {
     await element(by.id('tabs.settings')).tap();
 
     await scrollDownAndTap(
-      'main.settings.account.status.title',
+      'main.settings.account.status.input',
       'main.settings.index.view',
     );
     // @ts-ignore
@@ -115,8 +115,17 @@ describe('Change status message', () => {
       0.2,
     );
 
-    await expect(element(by.text(newStatusMessage))).toBeVisible();
+    // first tap is for closing keyboard (multiline), second for save
+    await element(by.id('main.settings.account.status.save')).tap();
 
     await forceLogout();
+    await scrollDownAndTap(
+      'onboarding.welcome.button',
+      'onboarding.welcome.view',
+    );
+
+    // Show updated status message in mentor list...
+    await expect(element(by.id('components.mentorList'))).toBeVisible();
+    await expect(element(by.text(newStatusMessage))).toBeVisible();
   });
 });

--- a/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
+++ b/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
@@ -34,6 +34,7 @@ const equalProps = (
   ) {
     const prev = prevProps.item as MessageProps;
     const next = nextProps.item as MessageProps;
+
     return prev.id === next.id && prev.isSeen === next.isSeen;
   }
 

--- a/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
+++ b/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as RN from 'react-native';
 
-import Message, { MessageProps } from './Message';
+import Message from './Message';
 import DateBubble from './DateBubble';
 import Spinner from 'src/Screens/components/Spinner';
 import { Renderable } from '.';
@@ -27,19 +27,7 @@ const RenderItem: React.FC<Props> = ({ item }) => {
 const equalProps = (
   prevProps: React.ComponentProps<typeof RenderItem>,
   nextProps: React.ComponentProps<typeof RenderItem>,
-) => {
-  if (
-    Object.prototype.hasOwnProperty.call(nextProps.item, 'isSeen') &&
-    Object.prototype.hasOwnProperty.call(prevProps.item, 'isSeen')
-  ) {
-    const prev = prevProps.item as MessageProps;
-    const next = nextProps.item as MessageProps;
-
-    return prev.id === next.id && prev.isSeen === next.isSeen;
-  }
-
-  return prevProps.item.id === nextProps.item.id;
-};
+) => prevProps.item.id === nextProps.item.id;
 
 export const MemoizedRenderItem = React.memo(RenderItem, equalProps);
 

--- a/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
+++ b/src/Screens/Main/Chat/MessageList/MemoizedRenderItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as RN from 'react-native';
 
-import Message from './Message';
+import Message, { MessageProps } from './Message';
 import DateBubble from './DateBubble';
 import Spinner from 'src/Screens/components/Spinner';
 import { Renderable } from '.';
@@ -27,7 +27,18 @@ const RenderItem: React.FC<Props> = ({ item }) => {
 const equalProps = (
   prevProps: React.ComponentProps<typeof RenderItem>,
   nextProps: React.ComponentProps<typeof RenderItem>,
-) => prevProps.item.id === nextProps.item.id;
+) => {
+  if (
+    Object.prototype.hasOwnProperty.call(nextProps.item, 'isSeen') &&
+    Object.prototype.hasOwnProperty.call(prevProps.item, 'isSeen')
+  ) {
+    const prev = prevProps.item as MessageProps;
+    const next = nextProps.item as MessageProps;
+    return prev.id === next.id && prev.isSeen === next.isSeen;
+  }
+
+  return prevProps.item.id === nextProps.item.id;
+};
 
 export const MemoizedRenderItem = React.memo(RenderItem, equalProps);
 

--- a/src/Screens/Main/Chat/MessageList/Message.tsx
+++ b/src/Screens/Main/Chat/MessageList/Message.tsx
@@ -20,10 +20,9 @@ const Message = ({ value: message }: MessageProps) => {
   const bubbleStyle =
     type === 'Received' ? styles.leftBubble : styles.rightBubble;
 
-  const isSeenTemp =
-    type === 'Received' && !message.isSeen
-      ? { borderWidth: 2, borderColor: 'red' }
-      : { borderWidth: 2, borderColor: 'green' };
+  // TODO: Visual aid, remove this after review
+  const isSeenBorder = type === 'Received' &&
+    !message.isSeen && { borderWidth: 2, borderColor: colors.orangeLight };
 
   const addZero = (n: number) => (n < 10 ? `0${n}` : `${n}`);
   const date = new Date(sentTime);
@@ -32,7 +31,7 @@ const Message = ({ value: message }: MessageProps) => {
   const timeText = `${hours}:${minutes}`;
 
   return (
-    <RN.View style={[bubbleStyle, isSeenTemp, styles.bubble]}>
+    <RN.View style={[bubbleStyle, isSeenBorder, styles.bubble]}>
       <RN.View>
         <RN.Text style={styles.text}>{content}</RN.Text>
       </RN.View>

--- a/src/Screens/Main/Chat/MessageList/Message.tsx
+++ b/src/Screens/Main/Chat/MessageList/Message.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
 import RN from 'react-native';
-import * as redux from 'redux';
-import { useDispatch } from 'react-redux';
-
-import { markSeen } from '../../../../state/reducers/markSeen';
-import * as actions from '../../../../state/actions';
 
 import colors from '../../../components/colors';
 import fonts from '../../../components/fonts';
@@ -16,19 +11,19 @@ export type MessageProps = {
   type: 'Message';
   value: messageApi.Message;
   id: string;
+  isSeen: boolean;
 };
 
 const Message = ({ value: message }: MessageProps) => {
   const { content, sentTime, type } = message;
-  const dispatch = useDispatch<redux.Dispatch<actions.Action>>();
-  React.useEffect(() => {
-    if (!message.isSeen && message.type === 'Received') {
-      dispatch(markSeen({ message }));
-    }
-  }, []);
 
   const bubbleStyle =
     type === 'Received' ? styles.leftBubble : styles.rightBubble;
+
+  const isSeenTemp =
+    type === 'Received' && !message.isSeen
+      ? { borderWidth: 2, borderColor: 'red' }
+      : { borderWidth: 2, borderColor: 'green' };
 
   const addZero = (n: number) => (n < 10 ? `0${n}` : `${n}`);
   const date = new Date(sentTime);
@@ -37,7 +32,7 @@ const Message = ({ value: message }: MessageProps) => {
   const timeText = `${hours}:${minutes}`;
 
   return (
-    <RN.View style={[bubbleStyle, styles.bubble]}>
+    <RN.View style={[bubbleStyle, isSeenTemp, styles.bubble]}>
       <RN.View>
         <RN.Text style={styles.text}>{content}</RN.Text>
       </RN.View>

--- a/src/Screens/Main/Chat/MessageList/Message.tsx
+++ b/src/Screens/Main/Chat/MessageList/Message.tsx
@@ -20,10 +20,6 @@ const Message = ({ value: message }: MessageProps) => {
   const bubbleStyle =
     type === 'Received' ? styles.leftBubble : styles.rightBubble;
 
-  // TODO: Visual aid, remove this after review
-  const isSeenBorder = type === 'Received' &&
-    !message.isSeen && { borderWidth: 2, borderColor: colors.orangeLight };
-
   const addZero = (n: number) => (n < 10 ? `0${n}` : `${n}`);
   const date = new Date(sentTime);
   const hours = addZero(date.getHours());
@@ -31,7 +27,7 @@ const Message = ({ value: message }: MessageProps) => {
   const timeText = `${hours}:${minutes}`;
 
   return (
-    <RN.View style={[bubbleStyle, isSeenBorder, styles.bubble]}>
+    <RN.View style={[bubbleStyle, styles.bubble]}>
       <RN.View>
         <RN.Text style={styles.text}>{content}</RN.Text>
       </RN.View>

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -105,6 +105,7 @@ export const MessageList = ({
     viewableItems: Array<RN.ViewToken>;
     changed: Array<RN.ViewToken>;
   };
+
   const handleViewableChanged = ({ changed }: ViewArgs) => {
     // TODO: Helper here, decode the changed maybe
     const unSeenMessagesOnScreen = changed
@@ -124,6 +125,7 @@ export const MessageList = ({
     itemVisiblePercentThreshold: 100,
     minimumViewTime: 1000,
   };
+
   const viewabilityConfigCallbackPairs = React.useRef([
     { viewabilityConfig, onViewableItemsChanged: handleViewableChanged },
   ]);

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import RN from 'react-native';
+import { useDispatch } from 'react-redux';
 
 import * as localization from '../../../../localization';
 
+import { markSeen } from '../../../../state/reducers/markSeen';
 import * as messageApi from '../../../../api/messages';
 
 import { MessageProps } from './Message';
@@ -55,6 +57,7 @@ export function toRenderable(
         type: 'Message' as const,
         value: m,
         id: m.messageId,
+        isSeen: m.isSeen,
       };
       const date = getDate(next.value.sentTime);
       const nextDate = { type: 'Date' as const, value: date, id: date };
@@ -81,13 +84,14 @@ export function toRenderable(
     : messageList;
 }
 
-const MessageList = ({
+export const MessageList = ({
   messageList,
   getPreviousMessages,
   isLoading,
 }: Props) => {
   const messages = toRenderable(messageList, isLoading);
   const previousItem = messageList.length > 0 ? messageList[0].messageId : '0';
+  const dispatch = useDispatch();
 
   const getPreviousMessagesIfNotLoading = () => {
     if (isLoading) {
@@ -97,11 +101,39 @@ const MessageList = ({
     getPreviousMessages(previousItem);
   };
 
+  type ViewArgs = {
+    viewableItems: Array<RN.ViewToken>;
+    changed: Array<RN.ViewToken>;
+  };
+  const handleViewableChanged = ({ changed }: ViewArgs) => {
+    // TODO: Helper here, decode the changed maybe
+    const unSeenMessagesOnScreen = changed
+      .filter(item => item.isViewable)
+      .filter(
+        ({ item }) =>
+          !item.isSeen && item.value && item.value.type === 'Received',
+      )
+      .map<messageApi.Message>(({ item }) => item.value);
+
+    console.log('changed', unSeenMessagesOnScreen);
+
+    dispatch(markSeen({ messages: unSeenMessagesOnScreen }));
+  };
+
+  const viewabilityConfig: RN.ViewabilityConfig = {
+    itemVisiblePercentThreshold: 100,
+    minimumViewTime: 1000,
+  };
+  const viewabilityConfigCallbackPairs = React.useRef([
+    { viewabilityConfig, onViewableItemsChanged: handleViewableChanged },
+  ]);
+
   return (
     <RN.FlatList
       contentContainerStyle={styles.scrollContent}
       data={messages}
       renderItem={({ item }) => <MemoizedRenderItem item={item} />}
+      viewabilityConfigCallbackPairs={viewabilityConfigCallbackPairs.current}
       keyExtractor={item => item.id}
       inverted={true}
       onEndReachedThreshold={0.01}
@@ -109,15 +141,6 @@ const MessageList = ({
     />
   );
 };
-
-const equalProps = (
-  prevProps: React.ComponentProps<typeof MessageList>,
-  nextProps: React.ComponentProps<typeof MessageList>,
-) =>
-  prevProps.messageList.length === nextProps.messageList.length &&
-  prevProps.isLoading === nextProps.isLoading;
-
-export const MemoizedMessageList = React.memo(MessageList, equalProps);
 
 const styles = RN.StyleSheet.create({
   scrollContent: {

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -116,8 +116,6 @@ export const MessageList = ({
       )
       .map<messageApi.Message>(({ item }) => item.value);
 
-    console.log('changed', unSeenMessagesOnScreen);
-
     dispatch(markSeen({ messages: unSeenMessagesOnScreen }));
   };
 

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -94,8 +94,6 @@ export const MessageList = ({
   const dispatch = useDispatch();
 
   const getPreviousMessagesIfNotLoading = () => {
-    console.log('messageList.length', messageList.length);
-
     if (isLoading || messageList.length < messageApi.MAX_MESSAGES_AT_ONCE) {
       return;
     }

--- a/src/Screens/Main/Chat/MessageList/index.tsx
+++ b/src/Screens/Main/Chat/MessageList/index.tsx
@@ -94,7 +94,9 @@ export const MessageList = ({
   const dispatch = useDispatch();
 
   const getPreviousMessagesIfNotLoading = () => {
-    if (isLoading) {
+    console.log('messageList.length', messageList.length);
+
+    if (isLoading || messageList.length < messageApi.MAX_MESSAGES_AT_ONCE) {
       return;
     }
 
@@ -107,7 +109,7 @@ export const MessageList = ({
   };
 
   const handleViewableChanged = ({ changed }: ViewArgs) => {
-    // TODO: Helper here, decode the changed maybe
+    // TODO: Decode 'changed' maybe
     const unSeenMessagesOnScreen = changed
       .filter(item => item.isViewable)
       .filter(
@@ -130,6 +132,7 @@ export const MessageList = ({
 
   return (
     <RN.FlatList
+      testID="main.buddy.messageList"
       contentContainerStyle={styles.scrollContent}
       data={messages}
       renderItem={({ item }) => <MemoizedRenderItem item={item} />}

--- a/src/Screens/Main/Chat/index.tsx
+++ b/src/Screens/Main/Chat/index.tsx
@@ -16,7 +16,7 @@ import { isDevice } from '../../../lib/isDevice';
 
 import Title from './Title';
 import Input from './Input';
-import { MemoizedMessageList } from './MessageList';
+import { MessageList } from './MessageList';
 import DropDown, { DropDownItem } from '../../components/DropDownMenu';
 import Modal from '../../components/Modal';
 import { dialogProperties, changeChatStatusOptions } from './chatProperties';
@@ -185,7 +185,7 @@ const Chat = ({ navigation, route }: Props) => {
             messageId="main.chat.send.failure"
           />
         )}
-        <MemoizedMessageList
+        <MessageList
           messageList={sortedMessageList}
           getPreviousMessages={getPreviousMessages}
           isLoading={isLoading}

--- a/src/Screens/Main/MentorCardExpanded.tsx
+++ b/src/Screens/Main/MentorCardExpanded.tsx
@@ -101,6 +101,7 @@ const MentorCardExpanded = ({ navigation, route }: Props) => {
             style={styles.button}
             onPress={shouldNavigateBack ? goBack : navigateToChat}
             messageId="main.mentorCardExpanded.button"
+            testID="main.mentorCardExpanded.button"
             disabled={isChatDisabled || isMe}
           />
         </SafeAreaView>

--- a/src/Screens/Main/UserReport/index.tsx
+++ b/src/Screens/Main/UserReport/index.tsx
@@ -11,6 +11,7 @@ import { StackScreenProps } from '@react-navigation/stack';
 import { StackRoutes } from '../..';
 import { ValidDescription } from 'src/lib/validators';
 import { isRight } from 'fp-ts/lib/Either';
+import { isDevice } from '../../../lib/isDevice';
 
 import { Title } from './Title';
 import TitledContainer from 'src/Screens/components/TitledContainer';
@@ -29,6 +30,8 @@ type Props = StackScreenProps<StackRoutes, 'Main/UserReport'>;
 
 const UserReport = ({ navigation, route }: Props) => {
   const reportedId = route.params?.reportedId;
+
+  const keyboardViewBehaviour = isDevice('ios') ? 'padding' : undefined;
 
   const { isLoading, isSuccess, isError } = ReactRedux.useSelector(
     selectUserReportStatus,
@@ -67,50 +70,54 @@ const UserReport = ({ navigation, route }: Props) => {
       TitleComponent={<Title onBack={handleBackPress} />}
       color={colors.darkBlue}
     >
-      <RN.ScrollView
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-        testID={'main.userreport.index.view'}
+      <RN.KeyboardAvoidingView
+        behavior={keyboardViewBehaviour}
+        style={styles.keyboardAvoider}
       >
-        <RN.View>
-          <Message style={styles.bodyText} id="main.userreport.bodyText1" />
-          <Message style={styles.bodyText} id="main.userreport.bodyText2" />
-          <NamedInputField
-            testID="main.userreport.description.input"
-            name="main.userreport.description.label"
-            style={styles.descriptionInput}
-            labelStyle={
-              isValidDescription ? styles.inputLabel : styles.errorLabel
-            }
-            inputStyle={
-              !isValidDescription ? styles.descriptionValidationError : {}
-            }
-            value={description}
-            onChangeText={setDescription}
-            onBlur={checkIsDescriptionValid}
-            multiline
-          />
-          {!isValidDescription && (
-            <Message
-              style={styles.validationMessage}
-              id="main.userreport.description.validationerror"
+        <RN.ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          <RN.View testID={'main.userreport.index.view'}>
+            <Message style={styles.bodyText} id="main.userreport.bodyText1" />
+            <Message style={styles.bodyText} id="main.userreport.bodyText2" />
+            <NamedInputField
+              testID="main.userreport.description.input"
+              name="main.userreport.description.label"
+              style={styles.descriptionInput}
+              labelStyle={
+                isValidDescription ? styles.inputLabel : styles.errorLabel
+              }
+              inputStyle={
+                !isValidDescription ? styles.descriptionValidationError : {}
+              }
+              value={description}
+              onChangeText={setDescription}
+              onBlur={checkIsDescriptionValid}
+              multiline
             />
-          )}
-          <NamedInputField
-            testID="main.userreport.contact.input"
-            name="main.userreport.contact.label"
-            labelStyle={styles.inputLabel}
-            value={contact}
-            onChangeText={setContact}
+            {!isValidDescription && (
+              <Message
+                style={styles.validationMessage}
+                id="main.userreport.description.validationerror"
+              />
+            )}
+            <NamedInputField
+              testID="main.userreport.contact.input"
+              name="main.userreport.contact.label"
+              labelStyle={styles.inputLabel}
+              value={contact}
+              onChangeText={setContact}
+            />
+          </RN.View>
+          <BottomActions
+            onBack={handleBackPress}
+            onSend={handleReport}
+            isSendDisabled={!isValidDescription || description.length === 0}
           />
-        </RN.View>
-        <BottomActions
-          onBack={handleBackPress}
-          onSend={handleReport}
-          isSendDisabled={!isValidDescription || description.length === 0}
-        />
-      </RN.ScrollView>
+        </RN.ScrollView>
+      </RN.KeyboardAvoidingView>
       {isError && (
         <Toast
           toastType="danger"
@@ -123,6 +130,9 @@ const UserReport = ({ navigation, route }: Props) => {
 };
 
 const styles = RN.StyleSheet.create({
+  keyboardAvoider: {
+    flex: 1,
+  },
   scrollView: {
     zIndex: 1,
     marginTop: -16,

--- a/src/Screens/components/MentorCard.tsx
+++ b/src/Screens/components/MentorCard.tsx
@@ -52,6 +52,7 @@ const MentorCard: React.FC<Props> = ({ onPress, style, mentor }) => {
           <Button
             style={styles.button}
             messageId="components.mentorCard.readMore"
+            testID="components.mentorCard.readMore"
             onPress={() => onPress(mentor)}
           />
         </RN.View>

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -209,7 +209,6 @@ export const getParamsForUnreadMessages = (
   messages: MessageMapping,
   params: PollingParams,
 ): Array<PollingParams> => {
-  console.log('getParamsForUnreadMessages');
   switch (params.type) {
     case 'OlderThan': {
       return getOlderThanParamsIfHasUnread(messages)(params.buddyId);
@@ -228,7 +227,6 @@ export const getParamsForUnreadMessages = (
 export const getOlderThanParamsIfHasUnread =
   (messages: MessageMapping) =>
   (buddyId: string): Array<PollingParams> => {
-    console.log('getOlderThanParamsIfHasUnread for buddyId:', buddyId);
     const buddyMessages = messages[buddyId] ?? {};
 
     const sorted = Object.keys(buddyMessages).map(
@@ -236,8 +234,6 @@ export const getOlderThanParamsIfHasUnread =
     );
 
     const hasUnread = sorted.some(message => !message.isSeen);
-
-    console.log('hasUnread', hasUnread);
 
     return hasUnread
       ? [{ type: 'OlderThan', buddyId, messageId: sorted[0].messageId }]

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -205,6 +205,16 @@ const sortSentTime = (a: Message, b: Message) => {
   return a.sentTime < b.sentTime ? -1 : 1;
 };
 
+export const getIsOldestFetchedMessageUnread = (
+  fetchedBuddyMessages: Record<string, Message>,
+) => {
+  const sorted = Object.keys(fetchedBuddyMessages)
+    .map(msgId => fetchedBuddyMessages[msgId])
+    .sort(sortSentTime);
+
+  return !sorted[sorted.length - 1].isSeen;
+};
+
 export const extractMostRecentId = (messages: MessageMapping) => {
   const flattenedMessages = Object.keys(messages).reduce<
     Record<string, Message>

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -20,6 +20,8 @@ import { isLeft } from 'fp-ts/lib/Either';
 
 type ApiMessage = t.TypeOf<typeof messageType>;
 
+export const MAX_MESSAGES_AT_ONCE = 10;
+
 const messageType = t.interface({
   content: t.string,
   recipient_id: t.string,
@@ -94,23 +96,21 @@ const reduceToMsgRecord = (acc: MessageMapping, message: Message) => ({
 });
 
 const createFetchParams = (pollingParams: PollingParams) => {
-  const maxMessagesAtOnce = 10;
-
   if (pollingParams.type === 'New' && pollingParams.previousMsgId.length > 0) {
-    return `from_message_id=${pollingParams.previousMsgId}&desc=false&max=${maxMessagesAtOnce}`;
+    return `from_message_id=${pollingParams.previousMsgId}&desc=false&max=${MAX_MESSAGES_AT_ONCE}`;
   }
 
   if (pollingParams.type === 'InitialMessages') {
     const userIds = pollingParams.buddyIds.join(',');
 
-    return `contact_user_ids=${userIds}&max=${maxMessagesAtOnce}&desc=true`;
+    return `contact_user_ids=${userIds}&max=${MAX_MESSAGES_AT_ONCE}&desc=true`;
   }
 
   if (pollingParams.type === 'OlderThan') {
-    return `contact_user_ids=${pollingParams.buddyId}&from_message_id=${pollingParams.messageId}&max=${maxMessagesAtOnce}&desc=true`;
+    return `contact_user_ids=${pollingParams.buddyId}&from_message_id=${pollingParams.messageId}&max=${MAX_MESSAGES_AT_ONCE}&desc=true`;
   }
 
-  return `max=${maxMessagesAtOnce}&desc=true`;
+  return `max=${MAX_MESSAGES_AT_ONCE}&desc=true`;
 };
 
 export type MessageResponse = {

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -209,15 +209,14 @@ export const getParamsForUnreadMessages = (
   messages: MessageMapping,
   params: PollingParams,
 ): Array<PollingParams> => {
+  console.log('getParamsForUnreadMessages');
   switch (params.type) {
     case 'OlderThan': {
-      return getOlderThanParamsIfOldestUnread(messages)(params.buddyId);
+      return getOlderThanParamsIfHasUnread(messages)(params.buddyId);
     }
 
     case 'InitialMessages': {
-      return params.buddyIds.flatMap(
-        getOlderThanParamsIfOldestUnread(messages),
-      );
+      return params.buddyIds.flatMap(getOlderThanParamsIfHasUnread(messages));
     }
 
     default: {
@@ -226,17 +225,21 @@ export const getParamsForUnreadMessages = (
   }
 };
 
-export const getOlderThanParamsIfOldestUnread =
+export const getOlderThanParamsIfHasUnread =
   (messages: MessageMapping) =>
   (buddyId: string): Array<PollingParams> => {
-    const sorted = Object.keys(messages[buddyId])
-      .map(msgId => messages[buddyId][msgId])
-      .sort(sortSentTime);
-    const oldest = sorted.length > 0 ? sorted[sorted.length - 1] : null;
-    const isOldestUnseen = oldest && !oldest.isSeen;
+    console.log('getOlderThanParamsIfHasUnread for buddyId:', buddyId);
+    const buddyMessages = messages[buddyId] ?? {};
+    const sorted = Object.keys(buddyMessages).map(
+      msgId => buddyMessages[msgId],
+    );
 
-    return isOldestUnseen
-      ? [{ type: 'OlderThan', buddyId, messageId: oldest.messageId }]
+    const hasUnread = sorted.some(message => !message.isSeen);
+
+    console.log('hasUnread', hasUnread);
+
+    return hasUnread
+      ? [{ type: 'OlderThan', buddyId, messageId: sorted[0].messageId }]
       : [];
   };
 

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -230,6 +230,7 @@ export const getOlderThanParamsIfHasUnread =
   (buddyId: string): Array<PollingParams> => {
     console.log('getOlderThanParamsIfHasUnread for buddyId:', buddyId);
     const buddyMessages = messages[buddyId] ?? {};
+
     const sorted = Object.keys(buddyMessages).map(
       msgId => buddyMessages[msgId],
     );

--- a/src/state/actions/regular.ts
+++ b/src/state/actions/regular.ts
@@ -83,7 +83,7 @@ type RegularActions = {
   'messages/setPollingParams': messages.PollingParams;
   'messages/get/completed': E.Either<string, messageApi.MessageResponse>;
 
-  'messages/markSeen': { message: messageApi.Message };
+  'messages/markSeen': { messages: Array<messageApi.Message> };
   'messages/markSeen/end': undefined;
 
   'buddies/completed': Result<typeof buddyApi.fetchBuddies>;

--- a/src/state/reducers/markSeen.ts
+++ b/src/state/reducers/markSeen.ts
@@ -39,10 +39,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
           type: 'messages/markSeen',
           payload: { messages },
         })),
-        // {
-        //   type: 'messages/markSeen',
-        //   payload: { messages },
-        // },
       );
     }
 

--- a/src/state/reducers/markSeen.ts
+++ b/src/state/reducers/markSeen.ts
@@ -41,6 +41,10 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
           type: 'messages/markSeen',
           payload: { messages },
         })),
+        // {
+        //   type: 'messages/markSeen',
+        //   payload: { messages },
+        // },
       );
     }
 

--- a/src/state/reducers/markSeen.ts
+++ b/src/state/reducers/markSeen.ts
@@ -26,8 +26,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
 
       const [first, ...messages] = action.payload.messages;
 
-      console.log('markSeen action for message', first.content);
-
       const nextState =
         first.messageId in state || first.isSeen || first.type === 'Sent'
           ? state

--- a/src/state/reducers/markSeen.ts
+++ b/src/state/reducers/markSeen.ts
@@ -16,6 +16,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
   switch (action.type) {
     case 'messages/markSeen': {
       const hasMessages = action.payload.messages.length > 0;
+
       if (!hasMessages) {
         return automaton.loop(state, {
           type: 'messages/markSeen/end',
@@ -26,6 +27,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       const [first, ...messages] = action.payload.messages;
 
       console.log('markSeen action for message', first.content);
+
       const nextState =
         first.messageId in state || first.isSeen || first.type === 'Sent'
           ? state
@@ -35,14 +37,10 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
 
       return automaton.loop(
         nextState,
-        // withToken(markSeenTask, () => ({
-        //   type: 'messages/markSeen',
-        //   payload: { messages },
-        // })),
-        {
+        withToken(markSeenTask, () => ({
           type: 'messages/markSeen',
           payload: { messages },
-        },
+        })),
       );
     }
 

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -100,17 +100,12 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       //  - mentor waits 5 seconds (the poll interval)
       //  - mentor scrolls up to the converstaion ( all messages have been loaded )
       //  - mentor opens chat
-      // case 2: marking unread message
-      // case 3: marking unread only for messages that are seen 100%
-      console.log('got messages', newMessages);
+      // TODO: remove borders of message-bubbles
 
       const newOlderThanParams = messageApi.getParamsForUnreadMessages(
         newMessages,
         state.currentParams,
       );
-
-      console.log('polled with', state.currentParams);
-      console.log('new older than params', newOlderThanParams);
 
       const [nextCurrent, nextQueue] = messageApi.getNextParams(
         action.payload,

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -102,10 +102,14 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       //  - mentor opens chat
       // case 2: marking unread message
       // case 3: marking unread only for messages that are seen 100%
+      console.log('got messages', newMessages);
       const newOlderThanParams = messageApi.getParamsForUnreadMessages(
         newMessages,
         state.currentParams,
       );
+
+      console.log('polled with', state.currentParams);
+      console.log('new older than params', newOlderThanParams);
 
       const [nextCurrent, nextQueue] = messageApi.getNextParams(
         action.payload,

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -16,7 +16,7 @@ import * as actions from '../actions';
 import * as types from '../types';
 
 import { withToken } from './accessToken';
-import { getIsBanned, getBuddyStatus } from '../selectors';
+import { getBuddyStatus } from '../selectors';
 
 export type State = types.AppState['messages'];
 export type LoopState = actions.LS<State>;
@@ -176,6 +176,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
 
     case 'messages/markSeen': {
       const hasMessages = action.payload.messages.length > 0;
+
       if (!hasMessages) {
         return state;
       }

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -103,6 +103,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
       // case 2: marking unread message
       // case 3: marking unread only for messages that are seen 100%
       console.log('got messages', newMessages);
+
       const newOlderThanParams = messageApi.getParamsForUnreadMessages(
         newMessages,
         state.currentParams,
@@ -132,7 +133,7 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
           messages: RD.success(nextMessages),
           previousMsgId,
           currentParams: nextCurrent,
-          pollingQueue: [...nextQueue, ...newOlderThanParams],
+          pollingQueue: [...newOlderThanParams, ...nextQueue],
         },
         nextCmd,
       );

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -93,15 +93,6 @@ export const reducer: automaton.Reducer<State, actions.Action> = (
 
       const previousMsgId = messageApi.extractMostRecentId(nextMessages);
 
-      // TODO: add some e2e-test
-      // case 1: oldermessage-fetching (for example initial)
-      //  - mentee sends 20 messages to mentor
-      //  - mentor login
-      //  - mentor waits 5 seconds (the poll interval)
-      //  - mentor scrolls up to the converstaion ( all messages have been loaded )
-      //  - mentor opens chat
-      // TODO: remove borders of message-bubbles
-
       const newOlderThanParams = messageApi.getParamsForUnreadMessages(
         newMessages,
         state.currentParams,

--- a/src/state/reducers/messages.ts
+++ b/src/state/reducers/messages.ts
@@ -16,7 +16,7 @@ import * as actions from '../actions';
 import * as types from '../types';
 
 import { withToken } from './accessToken';
-import { getBuddyStatus } from '../selectors';
+import { getBuddyStatus, getIsBanned } from '../selectors';
 
 export type State = types.AppState['messages'];
 export type LoopState = actions.LS<State>;
@@ -237,7 +237,10 @@ export const hasUnseen: (
   buddyId: string,
 ) => (appState: types.AppState) => boolean = buddyId => appState =>
   pipe(getMessagesByBuddyId(buddyId)(appState), messages =>
-    messages.some(({ type, isSeen }) => type === 'Received' && !isSeen),
+    messages.some(
+      ({ type, isSeen }) =>
+        type === 'Received' && !isSeen && !getIsBanned(buddyId)(appState),
+    ),
   );
 
 export const isAnyMessageUnseen = (appState: types.AppState) =>


### PR DESCRIPTION
### What has changed?
- When message is only fully visible on the viewport for 1s, then we mark it as unseen. 
- If fetching older messages for buddy or initial messages, and we receive a response where the oldest message is unseen, keep fetching until 
   a) received oldest message is not unread
   b) received all messages

Bonus:
User-report e2e-test was broken, so at the same time when fixed, I added a fix for this: https://trello.com/c/zYeyhfCO/936-keyboardavoider-to-user-report-form

### Why was the change made?
When investigating messaging issues reported by users, found out this oversight.
1. Message is always marked as read if the message is opened in the list (even if not visible!)
2. The unseen-selector of buddy-messages checks only the last received message, but its possible that user has only seen most recent unread messages, but has not scrolled to top


### Caveats?
- Dangerous to touch this logic, but tested it pretty well

### Related Trello issue
[Link to the Trello ticket](https://trello.com/c/HzYS4FRn/932-investigate-messages-not-showing-correctly)

### Checklist
- [x] I have updated relevant documentation in READMES
