### PR TITLE
Remove invalid UIRequiredDeviceCapabilities (ios)

### DIFF
--- a/ios/ylitse.xcodeproj/project.pbxproj
+++ b/ios/ylitse.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = ylitseTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -568,7 +568,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = L4F7DPRAF7;
 				INFOPLIST_FILE = ylitseTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -710,7 +710,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -790,7 +790,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/ylitse/Info.plist
+++ b/ios/ylitse/Info.plist
@@ -65,7 +65,6 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
### What has changed?
Bump min ios to 15.1 (RN 0.75.x)
Remove wrong UIRequiredDeviceCapabilities value


### Why was the change made?
- Minimum version should follow RN support
- The UIRequiredDeviceCapabilities was caught by AppStore


### Caveats?
NA


### Related Trello issue
[Trello-ticket](https://trello.com/c/b623OtSN/1003-release-2150)

### Checklist
- [ ] I have updated relevant documentation in READMES
